### PR TITLE
[DEV-5623] 公開API（出庫）の発送指示対応に伴うドキュメント修正

### DIFF
--- a/api.md
+++ b/api.md
@@ -307,6 +307,20 @@ Authorization: Bearer YOUR_TOKEN_HERE
     * delivery_date : 出庫日
     * estimated_delivery_date : 出庫予定日
     * etc : 摘要・備考
+  * shipping_instruction : 発送情報（フルプラン、かつ設定されている場合のみ表示されます）
+    * to_name : 宛名
+    * to_name_postfix : 敬称
+    * to_zip : 郵便番号
+    * to_address : 住所
+    * building_name : 建物名・部屋番号
+    * to_phone_number : 電話番号
+    * shipping_client_id : 発送元ID
+    * invoice_type_name : 便指定
+    * product_name_on_invoice : 品名
+    * freight_handling : 荷扱い
+    * freight_handling2 : 荷扱い
+    * arrival_date : 希望お届け日
+    * arrival_hour : 希望お届け時間帯
 
 + Request
     + Headers
@@ -347,6 +361,7 @@ Authorization: Bearer YOUR_TOKEN_HERE
                     + delivery_date: `2019-09-01` (string)
                     + estimated_delivery_date (string, optional, nullable)
                     + etc: (string) - 摘要・備考
+            + shipping_instruction (ShippingInstructionView)
         + ()
             + id: 11 (number)
             + num: 1001 (string)
@@ -397,6 +412,20 @@ Authorization: Bearer YOUR_TOKEN_HERE
             * unit_price : 納品単価
             * estimated_delivery_date : 出庫予定日
             * etc : 摘要・備考
+    * shipping_instruction : 発送情報（フルプランのみ設定できます）
+        * to_name : 宛名
+        * to_name_postfix : 敬称
+        * to_zip : 郵便番号
+        * to_address : 住所
+        * building_name : 建物名・部屋番号
+        * to_phone_number : 電話番号
+        * shipping_client_id : 発送元ID
+        * invoice_type_name : 便指定
+        * product_name_on_invoice : 品名
+        * freight_handling : 荷扱い
+        * freight_handling2 : 荷扱い
+        * arrival_date : 希望お届け日
+        * arrival_hour : 希望お届け時間帯
 
 + Request
     + Headers
@@ -410,6 +439,7 @@ Authorization: Bearer YOUR_TOKEN_HERE
         + status: `completed_delivery` (string, required) - 状態
         + delivery_date: `2019-09-01` (string) - 出庫日
         + deliveries (array[CreateDelivery], required)
+        + shipping_instruction (ShippingInstructionView)
 
 + Response 200 (application/json)
     + Attributes
@@ -457,6 +487,20 @@ Authorization: Bearer YOUR_TOKEN_HERE
     * delivery_date : 出庫日
     * estimated_delivery_date : 出庫予定日
     * etc: 摘要・備考
+  * shipping_instruction : 発送情報（フルプラン、かつ設定されている場合のみ表示されます）
+    * to_name : 宛名
+    * to_name_postfix : 敬称
+    * to_zip : 郵便番号
+    * to_address : 住所
+    * building_name : 建物名・部屋番号
+    * to_phone_number : 電話番号
+    * shipping_client_id : 発送元ID
+    * invoice_type_name : 便指定
+    * product_name_on_invoice : 品名
+    * freight_handling : 荷扱い
+    * freight_handling2 : 荷扱い
+    * arrival_date : 希望お届け日
+    * arrival_hour : 希望お届け時間帯
 
 + Parameters
     + id: 1 (number) - 出庫データのID
@@ -478,27 +522,28 @@ Authorization: Bearer YOUR_TOKEN_HERE
         + estimated_delivery_date: `2019-09-01` (string) - 出庫日
         + created_at: `2018-03-27T09:38:19+09:00`
         + updated_at: `2018-03-27T09:38:19+09:00`
-            + deliveries (array[object], fixed-type)
-                + (object)
-                    + inventory_id: 1 (number)
-                    + title: 掃除機 (string) - 物品名
-                    + quantity: 3 (number) - 出庫数量
-                    + unit: 台 (string) - 単位
-                    + unit_price: 100 (number) - 納品単価
-                    + status: completed_delivery (string)
-                    + delivery_date: `2019-09-01` (string)
-                    + estimated_delivery_date (string, optional, nullable)
-                    + etc: 白色 (string) - 摘要・備考
-                + (object)
-                    + inventory_id: 2 (number)
-                    + title: テレビ (string) - 物品名
-                    + quantity: 3 (number) - 出庫数量
-                    + unit: 台 (string) - 単位
-                    + unit_price: 100 (number) - 納品単価
-                    + status: completed_delivery (string)
-                    + delivery_date: `2019-09-01` (string)
-                    + estimated_delivery_date: `2019-09-01` (string, optional, nullable)
-                    + etc: (string) - 摘要・備考
+        + deliveries (array[object], fixed-type)
+            + (object)
+                + inventory_id: 1 (number)
+                + title: 掃除機 (string) - 物品名
+                + quantity: 3 (number) - 出庫数量
+                + unit: 台 (string) - 単位
+                + unit_price: 100 (number) - 納品単価
+                + status: completed_delivery (string)
+                + delivery_date: `2019-09-01` (string)
+                + estimated_delivery_date (string, optional, nullable)
+                + etc: 白色 (string) - 摘要・備考
+            + (object)
+                + inventory_id: 2 (number)
+                + title: テレビ (string) - 物品名
+                + quantity: 3 (number) - 出庫数量
+                + unit: 台 (string) - 単位
+                + unit_price: 100 (number) - 納品単価
+                + status: completed_delivery (string)
+                + delivery_date: `2019-09-01` (string)
+                + estimated_delivery_date: `2019-09-01` (string, optional, nullable)
+                + etc: (string) - 摘要・備考
+        + shipping_instruction (ShippingInstructionView)
 
 ## 出庫データ更新 [/api/v1/packing_slips/{id}]
 ### 出庫データ更新 [PUT]
@@ -522,6 +567,20 @@ Authorization: Bearer YOUR_TOKEN_HERE
             * delivery_date : 出庫日
             * estimated_delivery_date : 出庫予定日
             * etc : 摘要・備考
+    * shipping_instruction : 発送情報（フルプランのみ設定できます）
+        * to_name : 宛名
+        * to_name_postfix : 敬称
+        * to_zip : 郵便番号
+        * to_address : 住所
+        * building_name : 建物名・部屋番号
+        * to_phone_number : 電話番号
+        * shipping_client_id : 発送元ID
+        * invoice_type_name : 便指定
+        * product_name_on_invoice : 品名
+        * freight_handling : 荷扱い
+        * freight_handling2 : 荷扱い
+        * arrival_date : 希望お届け日
+        * arrival_hour : 希望お届け時間帯
 
 + Parameters
     + id: 1 (number) - 出庫データのID
@@ -536,6 +595,7 @@ Authorization: Bearer YOUR_TOKEN_HERE
         + num: 100 (string, optional) - 出庫データ番号（ユーザーが任意に設定できる番号）
         + customer_name: 株式会社ZAICO (string, optional) - 取引先名
         + deliveries (array[UpdateDeliveryToCompleted, UpdateDeliveryToBefore], required)
+        + shipping_instruction (ShippingInstructionView)
 
 + Response 200 (application/json)
     + Attributes
@@ -924,6 +984,21 @@ HOST: https://web.zaico.co.jp/
 + status: before_delivery
 + estimated_delivery_date: `2019-11-11` (string, optional, nullable)
 
+## ShippingInstructionView
++ to_name: `在庫商会` (string) - 宛名
++ to_name_postfix: `御中` (string) - 敬称
++ to_zip: `1000101` (string) - 郵便番号
++ to_address: `東京都大島町元町` (string) - 住所
++ building_name: `ザイコ工場` (string) - 建物名・部屋番号
++ to_phone_number: `0312341234` (string) - 電話番号
++ shipping_client_id: 123 (number) - 発送元ID
++ invoice_type_name: `宅急便（ヤマト）` (string) - 便指定
++ product_name_on_invoice: `化学薬品` (string) - 品名
++ freight_handling: `ワレ物注意` (string) - 荷扱い
++ freight_handling2: `下載厳禁` (string) - 荷扱い
++ arrival_date: `2023-10-31` (string) - 希望お届け日
++ arrival_hour: `14〜16時` (string) - 希望お届け時間帯
+
 ## CreatePurchaseItem (object)
 + inventory_id: 1 (number, required) - 在庫データID
 + quantity: 3 (number, required) - 入庫数量
@@ -1113,3 +1188,47 @@ HOST: https://web.zaico.co.jp/
 + code: 404 (number) - コード
 + status: `error` (string) - ステータス
 + message: `Customer not found` (string) - メッセージ
+
+
+# Group 発送元データ
+
+## 発送元データ一覧取得 [/api/v1/shipping_clients/]
+
+### GET
+
+#### 処理概要
+
+* フルプランのみ参照できます。
+* 自分のアカウントに登録されている発送元データのすべてを返します
+* 発送元データが1件も無い場合は、空の配列を返します
+* 発送元データが1000件以上ある場合はページネーションで分割され、1000件ごと発送元データを返します
+* 任意のページを取得するにはURLにクエリ「page=」をつけることで取得できます。
+* ページ情報はHTTPヘッダ"Link"に最初のページ、前のページ、次のページ、最後のページそれぞれ,(カンマ)で区切られ返されます。最初のページでは「前のページ」、最後のページでは「次のページ」項目は表示されません
+* Link, Total-Countヘッダは発送元一覧でのみ返されます
+
+  ```http
+  Ref：
+  https://web.zaico.co.jp/api/v1/shipping_clients?page=1
+  ```
+
+* Request
+  * Headers
+      Authorization: Bearer YOUR_TOKEN
+      Content-Type: application/json
+* Response 200 (application/json)
+  * Headers
+      Link: <https://web.zaico.co.jp/api/v1/shipping_clients?page=1>; rel="first", <https://web.zaico.co.jp/api/v1/shipping_clients?page=1>; rel="last"
+      Total-Count: 発送元データ件数
+  * Attributes (array)
+      * (ShippingClientsView)
+
+## Data Structures
+
+### ShippingClientsView
+
+* id: 1 (number) - レコードID
+* name: `発送元A` (string) - 名前/会社名
+* zip: `1234567` (string) - 郵便番号
+* address: `東京都港区` (string) - 住所
+* building_name: `港ビル` (string) - 建物名・部屋番号
+* phone_number: `08012345678` (string) - 電話番号

--- a/api.md
+++ b/api.md
@@ -314,7 +314,13 @@ Authorization: Bearer YOUR_TOKEN_HERE
     * to_address : 住所
     * building_name : 建物名・部屋番号
     * to_phone_number : 電話番号
-    * shipping_client_id : 発送元ID
+    * shipping_client : 発送元
+      * id : 発送元ID
+      * name : 名前/会社名
+      * zip : 郵便番号
+      * address : 住所
+      * building_name : 建物名・部屋番号
+      * phone_number : 電話番号
     * invoice_type_name : 便指定
     * product_name_on_invoice : 品名
     * freight_handling : 荷扱い
@@ -421,11 +427,15 @@ Authorization: Bearer YOUR_TOKEN_HERE
         * to_phone_number : 電話番号
         * shipping_client_id : 発送元ID
         * invoice_type_name : 便指定
+          * 指定可能な値 : `ヤマト 発払い` `ヤマト DM便` `ヤマト 着払い` `ヤマト ネコポス` `佐川 元払` `佐川 着払` `ゆうパケット` `クリックポスト` `その他`
         * product_name_on_invoice : 品名
         * freight_handling : 荷扱い
+          * 指定可能な値 : `指定なし` `ワレ物注意` `下載厳禁` `天地無用` `精密機器` `ナマモノ` `水濡厳禁` `取扱注意` （※「取扱注意」は佐川のみ）
         * freight_handling2 : 荷扱い
+          * 指定可能な値 : `指定なし` `ワレ物注意` `下載厳禁` `天地無用` `精密機器` `ナマモノ` `水濡厳禁` `取扱注意` （※「取扱注意」は佐川のみ）
         * arrival_date : 希望お届け日
         * arrival_hour : 希望お届け時間帯
+          * 指定可能な値 : `指定なし` `午前中` `14〜16時` `16〜18時` `18〜20時` `19〜21時`
 
 + Request
     + Headers
@@ -439,7 +449,7 @@ Authorization: Bearer YOUR_TOKEN_HERE
         + status: `completed_delivery` (string, required) - 状態
         + delivery_date: `2019-09-01` (string) - 出庫日
         + deliveries (array[CreateDelivery], required)
-        + shipping_instruction (ShippingInstructionView)
+        + shipping_instruction (ShippingInstructionParams)
 
 + Response 200 (application/json)
     + Attributes
@@ -494,7 +504,13 @@ Authorization: Bearer YOUR_TOKEN_HERE
     * to_address : 住所
     * building_name : 建物名・部屋番号
     * to_phone_number : 電話番号
-    * shipping_client_id : 発送元ID
+    * shipping_client : 発送元
+      * id : 発送元ID
+      * name : 名前/会社名
+      * zip : 郵便番号
+      * address : 住所
+      * building_name : 建物名・部屋番号
+      * phone_number : 電話番号
     * invoice_type_name : 便指定
     * product_name_on_invoice : 品名
     * freight_handling : 荷扱い
@@ -576,11 +592,15 @@ Authorization: Bearer YOUR_TOKEN_HERE
         * to_phone_number : 電話番号
         * shipping_client_id : 発送元ID
         * invoice_type_name : 便指定
+          * 指定可能な値 : `ヤマト 発払い` `ヤマト DM便` `ヤマト 着払い` `ヤマト ネコポス` `佐川 元払` `佐川 着払` `ゆうパケット` `クリックポスト` `その他`
         * product_name_on_invoice : 品名
         * freight_handling : 荷扱い
+          * 指定可能な値 : `指定なし` `ワレ物注意` `下載厳禁` `天地無用` `精密機器` `ナマモノ` `水濡厳禁` `取扱注意` （※「取扱注意」は佐川のみ）
         * freight_handling2 : 荷扱い
+          * 指定可能な値 : `指定なし` `ワレ物注意` `下載厳禁` `天地無用` `精密機器` `ナマモノ` `水濡厳禁` `取扱注意` （※「取扱注意」は佐川のみ）
         * arrival_date : 希望お届け日
         * arrival_hour : 希望お届け時間帯
+          * 指定可能な値 : `指定なし` `午前中` `14〜16時` `16〜18時` `18〜20時` `19〜21時`
 
 + Parameters
     + id: 1 (number) - 出庫データのID
@@ -595,7 +615,7 @@ Authorization: Bearer YOUR_TOKEN_HERE
         + num: 100 (string, optional) - 出庫データ番号（ユーザーが任意に設定できる番号）
         + customer_name: 株式会社ZAICO (string, optional) - 取引先名
         + deliveries (array[UpdateDeliveryToCompleted, UpdateDeliveryToBefore], required)
-        + shipping_instruction (ShippingInstructionView)
+        + shipping_instruction (ShippingInstructionParams)
 
 + Response 200 (application/json)
     + Attributes
@@ -991,13 +1011,29 @@ HOST: https://web.zaico.co.jp/
 + to_address: `東京都大島町元町` (string) - 住所
 + building_name: `ザイコ工場` (string) - 建物名・部屋番号
 + to_phone_number: `0312341234` (string) - 電話番号
-+ shipping_client_id: 123 (number) - 発送元ID
-+ invoice_type_name: `宅急便（ヤマト）` (string) - 便指定
+* shipping_client (ShippingClientsView) - 発送元
+* invoice_type_name: `ヤマト 発払い` (string) - 便指定
 + product_name_on_invoice: `化学薬品` (string) - 品名
 + freight_handling: `ワレ物注意` (string) - 荷扱い
 + freight_handling2: `下載厳禁` (string) - 荷扱い
 + arrival_date: `2023-10-31` (string) - 希望お届け日
 + arrival_hour: `14〜16時` (string) - 希望お届け時間帯
+
+## ShippingInstructionParams
+
++ to_name: `在庫商会` (string) - 宛名
+* to_name_postfix: `御中` (string) - 敬称
+* to_zip: `1000101` (string) - 郵便番号
+* to_address: `東京都大島町元町` (string) - 住所
+* building_name: `ザイコ工場` (string) - 建物名・部屋番号
+* to_phone_number: `0312341234` (string) - 電話番号
+* shipping_client_id: 123 (number) - 発送元ID
+* invoice_type_name: `ヤマト 発払い` (string) - 便指定
++ product_name_on_invoice: `化学薬品` (string) - 品名
+* freight_handling: `ワレ物注意` (string) - 荷扱い
+* freight_handling2: `下載厳禁` (string) - 荷扱い
+* arrival_date: `2023-10-31` (string) - 希望お届け日
+* arrival_hour: `14〜16時` (string) - 希望お届け時間帯
 
 ## CreatePurchaseItem (object)
 + inventory_id: 1 (number, required) - 在庫データID

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><meta charset="utf-8"><title>zaico API Document</title><link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"><style>@import url('https://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200');.hljs-comment,.hljs-title{color:#8e908c}.hljs-variable,.hljs-attribute,.hljs-tag,.hljs-regexp,.ruby .hljs-constant,.xml .hljs-tag .hljs-title,.xml .hljs-pi,.xml .hljs-doctype,.html .hljs-doctype,.css .hljs-id,.css .hljs-class,.css .hljs-pseudo{color:#c82829}.hljs-number,.hljs-preprocessor,.hljs-pragma,.hljs-built_in,.hljs-literal,.hljs-params,.hljs-constant{color:#f5871f}.ruby .hljs-class .hljs-title,.css .hljs-rules .hljs-attribute{color:#eab700}.hljs-string,.hljs-value,.hljs-inheritance,.hljs-header,.ruby .hljs-symbol,.xml .hljs-cdata{color:#718c00}.css .hljs-hexcolor{color:#3e999f}.hljs-function,.python .hljs-decorator,.python .hljs-title,.ruby .hljs-function .hljs-title,.ruby .hljs-title .hljs-keyword,.perl .hljs-sub,.javascript .hljs-title,.coffeescript .hljs-title{color:#4271ae}.hljs-keyword,.javascript .hljs-function{color:#8959a8}.hljs{display:block;background:white;color:#4d4d4c;padding:.5em}.coffeescript .javascript,.javascript .xml,.tex .hljs-formula,.xml .javascript,.xml .vbscript,.xml .css,.xml .hljs-cdata{opacity:.5}.right .hljs-comment{color:#969896}.right .css .hljs-class,.right .css .hljs-id,.right .css .hljs-pseudo,.right .hljs-attribute,.right .hljs-regexp,.right .hljs-tag,.right .hljs-variable,.right .html .hljs-doctype,.right .ruby .hljs-constant,.right .xml .hljs-doctype,.right .xml .hljs-pi,.right .xml .hljs-tag .hljs-title{color:#c66}.right .hljs-built_in,.right .hljs-constant,.right .hljs-literal,.right .hljs-number,.right .hljs-params,.right .hljs-pragma,.right .hljs-preprocessor{color:#de935f}.right .css .hljs-rule .hljs-attribute,.right .ruby .hljs-class .hljs-title{color:#f0c674}.right .hljs-header,.right .hljs-inheritance,.right .hljs-name,.right .hljs-string,.right .hljs-value,.right .ruby .hljs-symbol,.right .xml .hljs-cdata{color:#b5bd68}.right .css .hljs-hexcolor,.right .hljs-title{color:#8abeb7}.right .coffeescript .hljs-title,.right .hljs-function,.right .javascript .hljs-title,.right .perl .hljs-sub,.right .python .hljs-decorator,.right .python .hljs-title,.right .ruby .hljs-function .hljs-title,.right .ruby .hljs-title .hljs-keyword{color:#81a2be}.right .hljs-keyword,.right .javascript .hljs-function{color:#b294bb}.right .hljs{display:block;overflow-x:auto;background:#1d1f21;color:#c5c8c6;padding:.5em;-webkit-text-size-adjust:none}.right .coffeescript .javascript,.right .javascript .xml,.right .tex .hljs-formula,.right .xml .css,.right .xml .hljs-cdata,.right .xml .javascript,.right .xml .vbscript{opacity:.5}body{color:black;background:white;font:400 14px / 1.42 'Roboto',Helvetica,sans-serif}header{border-bottom:1px solid #f2f2f2;margin-bottom:12px}h1,h2,h3,h4,h5{color:black;margin:12px 0}h1 .permalink,h2 .permalink,h3 .permalink,h4 .permalink,h5 .permalink{margin-left:0;opacity:0;transition:opacity .25s ease}h1:hover .permalink,h2:hover .permalink,h3:hover .permalink,h4:hover .permalink,h5:hover .permalink{opacity:1}.triple h1 .permalink,.triple h2 .permalink,.triple h3 .permalink,.triple h4 .permalink,.triple h5 .permalink{opacity:.15}.triple h1:hover .permalink,.triple h2:hover .permalink,.triple h3:hover .permalink,.triple h4:hover .permalink,.triple h5:hover .permalink{opacity:.15}h1{font:200 36px 'Raleway',Helvetica,sans-serif;font-size:36px}h2{font:200 36px 'Raleway',Helvetica,sans-serif;font-size:30px}h3{font-size:100%;text-transform:uppercase}h5{font-size:100%;font-weight:normal}p{margin:0 0 10px}p.choices{line-height:1.6}a{color:#428bca;text-decoration:none}li p{margin:0}hr.split{border:0;height:1px;width:100%;padding-left:6px;margin:12px auto;background-image:linear-gradient(to right, rgba(0,0,0,0) 20%, rgba(0,0,0,0.2) 51.4%, rgba(255,255,255,0.2) 51.4%, rgba(255,255,255,0) 80%)}dl dt{float:left;width:130px;clear:left;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:700}dl dd{margin-left:150px}blockquote{color:rgba(0,0,0,0.5);font-size:15.5px;padding:10px 20px;margin:12px 0;border-left:5px solid #e8e8e8}blockquote p:last-child{margin-bottom:0}pre{background-color:#f5f5f5;padding:12px;border:1px solid #cfcfcf;border-radius:6px;overflow:auto}pre code{color:black;background-color:transparent;padding:0;border:none}code{color:#444;background-color:#f5f5f5;font:'Inconsolata',monospace;padding:1px 4px;border:1px solid #cfcfcf;border-radius:3px}ul,ol{padding-left:2em}table{border-collapse:collapse;border-spacing:0;margin-bottom:12px}table tr:nth-child(2n){background-color:#fafafa}table th,table td{padding:6px 12px;border:1px solid #e6e6e6}.text-muted{opacity:.5}.note,.warning{padding:.3em 1em;margin:1em 0;border-radius:2px;font-size:90%}.note h1,.warning h1,.note h2,.warning h2,.note h3,.warning h3,.note h4,.warning h4,.note h5,.warning h5,.note h6,.warning h6{font-family:200 36px 'Raleway',Helvetica,sans-serif;font-size:135%;font-weight:500}.note p,.warning p{margin:.5em 0}.note{color:black;background-color:#f0f6fb;border-left:4px solid #428bca}.note h1,.note h2,.note h3,.note h4,.note h5,.note h6{color:#428bca}.warning{color:black;background-color:#fbf1f0;border-left:4px solid #c9302c}.warning h1,.warning h2,.warning h3,.warning h4,.warning h5,.warning h6{color:#c9302c}header{margin-top:24px}nav{position:fixed;top:24px;bottom:0;overflow-y:auto}nav .resource-group{padding:0}nav .resource-group .heading{position:relative}nav .resource-group .heading .chevron{position:absolute;top:12px;right:12px;opacity:.5}nav .resource-group .heading a{display:block;color:black;opacity:.7;border-left:2px solid transparent;margin:0}nav .resource-group .heading a:hover{text-decoration:none;background-color:bad-color;border-left:2px solid black}nav ul{list-style-type:none;padding-left:0}nav ul a{display:block;font-size:13px;color:rgba(0,0,0,0.7);padding:8px 12px;border-top:1px solid #d9d9d9;border-left:2px solid transparent;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}nav ul a:hover{text-decoration:none;background-color:bad-color;border-left:2px solid black}nav ul>li{margin:0}nav ul>li:first-child{margin-top:-12px}nav ul>li:last-child{margin-bottom:-12px}nav ul ul a{padding-left:24px}nav ul ul li{margin:0}nav ul ul li:first-child{margin-top:0}nav ul ul li:last-child{margin-bottom:0}nav>div>div>ul>li:first-child>a{border-top:none}.preload *{transition:none !important}.pull-left{float:left}.pull-right{float:right}.badge{display:inline-block;float:right;min-width:10px;min-height:14px;padding:3px 7px;font-size:12px;color:#000;background-color:#f2f2f2;border-radius:10px;margin:-2px 0}.badge.get{color:#70bbe1;background-color:#d9edf7}.badge.head{color:#70bbe1;background-color:#d9edf7}.badge.options{color:#70bbe1;background-color:#d9edf7}.badge.put{color:#f0db70;background-color:#fcf8e3}.badge.patch{color:#f0db70;background-color:#fcf8e3}.badge.post{color:#93cd7c;background-color:#dff0d8}.badge.delete{color:#ce8383;background-color:#f2dede}.collapse-button{float:right}.collapse-button .close{display:none;color:#428bca;cursor:pointer}.collapse-button .open{color:#428bca;cursor:pointer}.collapse-button.show .close{display:inline}.collapse-button.show .open{display:none}.collapse-content{max-height:0;overflow:hidden;transition:max-height .3s ease-in-out}nav{width:220px}.container{max-width:940px;margin-left:auto;margin-right:auto}.container .row .content{margin-left:244px;width:696px}.container .row:after{content:'';display:block;clear:both}.container-fluid nav{width:22%}.container-fluid .row .content{margin-left:24%}.container-fluid.triple nav{width:16.5%;padding-right:1px}.container-fluid.triple .row .content{position:relative;margin-left:16.5%;padding-left:24px}.middle:before,.middle:after{content:'';display:table}.middle:after{clear:both}.middle{box-sizing:border-box;width:51.5%;padding-right:12px}.right{box-sizing:border-box;float:right;width:48.5%;padding-left:12px}.right a{color:#428bca}.right h1,.right h2,.right h3,.right h4,.right h5,.right p,.right div{color:white}.right pre{background-color:#1d1f21;border:1px solid #1d1f21}.right pre code{color:#c5c8c6}.right .description{margin-top:12px}.triple .resource-heading{font-size:125%}.definition{margin-top:12px;margin-bottom:12px}.definition .method{font-weight:bold}.definition .method.get{color:#2e8ab8}.definition .method.head{color:#2e8ab8}.definition .method.options{color:#2e8ab8}.definition .method.post{color:#56b82e}.definition .method.put{color:#b8a22e}.definition .method.patch{color:#b8a22e}.definition .method.delete{color:#b82e2e}.definition .uri{word-break:break-all;word-wrap:break-word}.definition .hostname{opacity:.5}.example-names{background-color:#eee;padding:12px;border-radius:6px}.example-names .tab-button{cursor:pointer;color:black;border:1px solid #ddd;padding:6px;margin-left:12px}.example-names .tab-button.active{background-color:#d5d5d5}.right .example-names{background-color:#444}.right .example-names .tab-button{color:white;border:1px solid #666;border-radius:6px}.right .example-names .tab-button.active{background-color:#5e5e5e}#nav-background{position:fixed;left:0;top:0;bottom:0;width:16.5%;padding-right:14.4px;background-color:#fbfbfb;border-right:1px solid #f0f0f0;z-index:-1}#right-panel-background{position:absolute;right:-12px;top:-12px;bottom:-12px;width:48.6%;background-color:#333;z-index:-1}@media (max-width:1200px){nav{width:198px}.container{max-width:840px}.container .row .content{margin-left:224px;width:606px}}@media (max-width:992px){nav{width:169.4px}.container{max-width:720px}.container .row .content{margin-left:194px;width:526px}}@media (max-width:768px){nav{display:none}.container{width:95%;max-width:none}.container .row .content,.container-fluid .row .content,.container-fluid.triple .row .content{margin-left:auto;margin-right:auto;width:95%}#nav-background{display:none}#right-panel-background{width:48.6%}}.back-to-top{position:fixed;z-index:1;bottom:0;right:24px;padding:4px 8px;color:rgba(0,0,0,0.5);background-color:#f2f2f2;text-decoration:none !important;border-top:1px solid #d9d9d9;border-left:1px solid #d9d9d9;border-right:1px solid #d9d9d9;border-top-left-radius:3px;border-top-right-radius:3px}.resource-group{padding:12px;margin-bottom:12px;background-color:white;border:1px solid #d9d9d9;border-radius:6px}.resource-group h2.group-heading,.resource-group .heading a{padding:12px;margin:-12px -12px 12px -12px;background-color:#f2f2f2;border-bottom:1px solid #d9d9d9;border-top-left-radius:6px;border-top-right-radius:6px;white-space:nowrap;text-overflow:ellipsis;overflow:hidden}.triple .content .resource-group{padding:0;border:none}.triple .content .resource-group h2.group-heading,.triple .content .resource-group .heading a{margin:0 0 12px 0;border:1px solid #d9d9d9}nav .resource-group .heading a{padding:12px;margin-bottom:0}nav .resource-group .collapse-content{padding:0}.action{margin-bottom:12px;padding:12px 12px 0 12px;overflow:hidden;border:1px solid transparent;border-radius:6px}.action h4.action-heading{padding:6px 12px;margin:-12px -12px 12px -12px;border-bottom:1px solid transparent;border-top-left-radius:6px;border-top-right-radius:6px;overflow:hidden}.action h4.action-heading .name{float:right;font-weight:normal;padding:6px 0}.action h4.action-heading .method{padding:6px 12px;margin-right:12px;border-radius:3px;display:inline-block}.action h4.action-heading .method.get{color:#fff;background-color:#337ab7}.action h4.action-heading .method.head{color:#fff;background-color:#337ab7}.action h4.action-heading .method.options{color:#fff;background-color:#337ab7}.action h4.action-heading .method.put{color:#fff;background-color:#ed9c28}.action h4.action-heading .method.patch{color:#fff;background-color:#ed9c28}.action h4.action-heading .method.post{color:#fff;background-color:#5cb85c}.action h4.action-heading .method.delete{color:#fff;background-color:#d9534f}.action h4.action-heading code{color:#444;background-color:#f5f5f5;border-color:#cfcfcf;font-weight:normal;word-break:break-all;display:inline-block;margin-top:2px}.action dl.inner{padding-bottom:2px}.action .title{border-bottom:1px solid white;margin:0 -12px -1px -12px;padding:12px}.action.get{border-color:#bce8f1}.action.get h4.action-heading{color:#337ab7;background:#d9edf7;border-bottom-color:#bce8f1}.action.head{border-color:#bce8f1}.action.head h4.action-heading{color:#337ab7;background:#d9edf7;border-bottom-color:#bce8f1}.action.options{border-color:#bce8f1}.action.options h4.action-heading{color:#337ab7;background:#d9edf7;border-bottom-color:#bce8f1}.action.post{border-color:#d6e9c6}.action.post h4.action-heading{color:#5cb85c;background:#dff0d8;border-bottom-color:#d6e9c6}.action.put{border-color:#faebcc}.action.put h4.action-heading{color:#ed9c28;background:#fcf8e3;border-bottom-color:#faebcc}.action.patch{border-color:#faebcc}.action.patch h4.action-heading{color:#ed9c28;background:#fcf8e3;border-bottom-color:#faebcc}.action.delete{border-color:#ebccd1}.action.delete h4.action-heading{color:#d9534f;background:#f2dede;border-bottom-color:#ebccd1}</style></head><body class="preload"><a href="#top" class="text-muted back-to-top"><i class="fa fa-toggle-up"></i>&nbsp;Back to top</a><div class="container"><div class="row"><nav><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#認証">認証</a></div><div class="collapse-content"><ul><li><a href="#header-認証について">認証について</a></li><li><a href="#header-get">GET</a></li><li><a href="#header-概要">概要</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#在庫データ">在庫データ</a></div><div class="collapse-content"><ul><li><a href="#在庫データ-在庫データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>在庫データ一覧取得</a></li><li><a href="#在庫データ-在庫データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>在庫データ作成</a></li><li><a href="#在庫データ-在庫データ個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>在庫データ個別取得</a></li><li><a href="#在庫データ-在庫データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>在庫データ更新</a></li><li><a href="#在庫データ-在庫データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>在庫データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#出庫データ">出庫データ</a></div><div class="collapse-content"><ul><li><a href="#出庫データ-出庫データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>出庫データ一覧取得</a></li><li><a href="#出庫データ-出庫データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>出庫データ作成</a></li><li><a href="#出庫データ-出庫データ個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>出庫データ個別取得</a></li><li><a href="#出庫データ-出庫データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>出庫データ更新</a></li><li><a href="#出庫データ-出庫データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>出庫データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#入庫データ">入庫データ</a></div><div class="collapse-content"><ul><li><a href="#入庫データ-入庫データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>入庫データ一覧取得</a></li><li><a href="#入庫データ-入庫データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>入庫データ作成</a></li><li><a href="#入庫データ-入庫データ個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>入庫データ個別取得</a></li><li><a href="#入庫データ-入庫データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>入庫データ更新</a></li><li><a href="#入庫データ-入庫データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>入庫データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#取引先データ">取引先データ</a></div><div class="collapse-content"><ul><li><a href="#取引先データ-取引先データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>取引先データ一覧取得</a></li><li><a href="#取引先データ-取引先データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>取引先データ作成</a></li><li><a href="#取引先データ-取引先データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>取引先データ更新</a></li><li><a href="#取引先データ-取引先データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>取引先データ削除</a></li></ul></div></div><p style="text-align: center; word-wrap: break-word;"><a href="https://web.zaico.co.jp">https://web.zaico.co.jp</a></p></nav><div class="content"><header><h1 id="top">zaico API Document</h1></header><p>このドキュメントはZAICO APIの機能と使うために必要なパラメータなどを説明するものです。<br>
+<!DOCTYPE html><html><head><meta charset="utf-8"><title>zaico API Document</title><link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"><style>@import url('https://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200');.hljs-comment,.hljs-title{color:#8e908c}.hljs-variable,.hljs-attribute,.hljs-tag,.hljs-regexp,.ruby .hljs-constant,.xml .hljs-tag .hljs-title,.xml .hljs-pi,.xml .hljs-doctype,.html .hljs-doctype,.css .hljs-id,.css .hljs-class,.css .hljs-pseudo{color:#c82829}.hljs-number,.hljs-preprocessor,.hljs-pragma,.hljs-built_in,.hljs-literal,.hljs-params,.hljs-constant{color:#f5871f}.ruby .hljs-class .hljs-title,.css .hljs-rules .hljs-attribute{color:#eab700}.hljs-string,.hljs-value,.hljs-inheritance,.hljs-header,.ruby .hljs-symbol,.xml .hljs-cdata{color:#718c00}.css .hljs-hexcolor{color:#3e999f}.hljs-function,.python .hljs-decorator,.python .hljs-title,.ruby .hljs-function .hljs-title,.ruby .hljs-title .hljs-keyword,.perl .hljs-sub,.javascript .hljs-title,.coffeescript .hljs-title{color:#4271ae}.hljs-keyword,.javascript .hljs-function{color:#8959a8}.hljs{display:block;background:white;color:#4d4d4c;padding:.5em}.coffeescript .javascript,.javascript .xml,.tex .hljs-formula,.xml .javascript,.xml .vbscript,.xml .css,.xml .hljs-cdata{opacity:.5}.right .hljs-comment{color:#969896}.right .css .hljs-class,.right .css .hljs-id,.right .css .hljs-pseudo,.right .hljs-attribute,.right .hljs-regexp,.right .hljs-tag,.right .hljs-variable,.right .html .hljs-doctype,.right .ruby .hljs-constant,.right .xml .hljs-doctype,.right .xml .hljs-pi,.right .xml .hljs-tag .hljs-title{color:#c66}.right .hljs-built_in,.right .hljs-constant,.right .hljs-literal,.right .hljs-number,.right .hljs-params,.right .hljs-pragma,.right .hljs-preprocessor{color:#de935f}.right .css .hljs-rule .hljs-attribute,.right .ruby .hljs-class .hljs-title{color:#f0c674}.right .hljs-header,.right .hljs-inheritance,.right .hljs-name,.right .hljs-string,.right .hljs-value,.right .ruby .hljs-symbol,.right .xml .hljs-cdata{color:#b5bd68}.right .css .hljs-hexcolor,.right .hljs-title{color:#8abeb7}.right .coffeescript .hljs-title,.right .hljs-function,.right .javascript .hljs-title,.right .perl .hljs-sub,.right .python .hljs-decorator,.right .python .hljs-title,.right .ruby .hljs-function .hljs-title,.right .ruby .hljs-title .hljs-keyword{color:#81a2be}.right .hljs-keyword,.right .javascript .hljs-function{color:#b294bb}.right .hljs{display:block;overflow-x:auto;background:#1d1f21;color:#c5c8c6;padding:.5em;-webkit-text-size-adjust:none}.right .coffeescript .javascript,.right .javascript .xml,.right .tex .hljs-formula,.right .xml .css,.right .xml .hljs-cdata,.right .xml .javascript,.right .xml .vbscript{opacity:.5}body{color:black;background:white;font:400 14px / 1.42 'Roboto',Helvetica,sans-serif}header{border-bottom:1px solid #f2f2f2;margin-bottom:12px}h1,h2,h3,h4,h5{color:black;margin:12px 0}h1 .permalink,h2 .permalink,h3 .permalink,h4 .permalink,h5 .permalink{margin-left:0;opacity:0;transition:opacity .25s ease}h1:hover .permalink,h2:hover .permalink,h3:hover .permalink,h4:hover .permalink,h5:hover .permalink{opacity:1}.triple h1 .permalink,.triple h2 .permalink,.triple h3 .permalink,.triple h4 .permalink,.triple h5 .permalink{opacity:.15}.triple h1:hover .permalink,.triple h2:hover .permalink,.triple h3:hover .permalink,.triple h4:hover .permalink,.triple h5:hover .permalink{opacity:.15}h1{font:200 36px 'Raleway',Helvetica,sans-serif;font-size:36px}h2{font:200 36px 'Raleway',Helvetica,sans-serif;font-size:30px}h3{font-size:100%;text-transform:uppercase}h5{font-size:100%;font-weight:normal}p{margin:0 0 10px}p.choices{line-height:1.6}a{color:#428bca;text-decoration:none}li p{margin:0}hr.split{border:0;height:1px;width:100%;padding-left:6px;margin:12px auto;background-image:linear-gradient(to right, rgba(0,0,0,0) 20%, rgba(0,0,0,0.2) 51.4%, rgba(255,255,255,0.2) 51.4%, rgba(255,255,255,0) 80%)}dl dt{float:left;width:130px;clear:left;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:700}dl dd{margin-left:150px}blockquote{color:rgba(0,0,0,0.5);font-size:15.5px;padding:10px 20px;margin:12px 0;border-left:5px solid #e8e8e8}blockquote p:last-child{margin-bottom:0}pre{background-color:#f5f5f5;padding:12px;border:1px solid #cfcfcf;border-radius:6px;overflow:auto}pre code{color:black;background-color:transparent;padding:0;border:none}code{color:#444;background-color:#f5f5f5;font:'Inconsolata',monospace;padding:1px 4px;border:1px solid #cfcfcf;border-radius:3px}ul,ol{padding-left:2em}table{border-collapse:collapse;border-spacing:0;margin-bottom:12px}table tr:nth-child(2n){background-color:#fafafa}table th,table td{padding:6px 12px;border:1px solid #e6e6e6}.text-muted{opacity:.5}.note,.warning{padding:.3em 1em;margin:1em 0;border-radius:2px;font-size:90%}.note h1,.warning h1,.note h2,.warning h2,.note h3,.warning h3,.note h4,.warning h4,.note h5,.warning h5,.note h6,.warning h6{font-family:200 36px 'Raleway',Helvetica,sans-serif;font-size:135%;font-weight:500}.note p,.warning p{margin:.5em 0}.note{color:black;background-color:#f0f6fb;border-left:4px solid #428bca}.note h1,.note h2,.note h3,.note h4,.note h5,.note h6{color:#428bca}.warning{color:black;background-color:#fbf1f0;border-left:4px solid #c9302c}.warning h1,.warning h2,.warning h3,.warning h4,.warning h5,.warning h6{color:#c9302c}header{margin-top:24px}nav{position:fixed;top:24px;bottom:0;overflow-y:auto}nav .resource-group{padding:0}nav .resource-group .heading{position:relative}nav .resource-group .heading .chevron{position:absolute;top:12px;right:12px;opacity:.5}nav .resource-group .heading a{display:block;color:black;opacity:.7;border-left:2px solid transparent;margin:0}nav .resource-group .heading a:hover{text-decoration:none;background-color:bad-color;border-left:2px solid black}nav ul{list-style-type:none;padding-left:0}nav ul a{display:block;font-size:13px;color:rgba(0,0,0,0.7);padding:8px 12px;border-top:1px solid #d9d9d9;border-left:2px solid transparent;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}nav ul a:hover{text-decoration:none;background-color:bad-color;border-left:2px solid black}nav ul>li{margin:0}nav ul>li:first-child{margin-top:-12px}nav ul>li:last-child{margin-bottom:-12px}nav ul ul a{padding-left:24px}nav ul ul li{margin:0}nav ul ul li:first-child{margin-top:0}nav ul ul li:last-child{margin-bottom:0}nav>div>div>ul>li:first-child>a{border-top:none}.preload *{transition:none !important}.pull-left{float:left}.pull-right{float:right}.badge{display:inline-block;float:right;min-width:10px;min-height:14px;padding:3px 7px;font-size:12px;color:#000;background-color:#f2f2f2;border-radius:10px;margin:-2px 0}.badge.get{color:#70bbe1;background-color:#d9edf7}.badge.head{color:#70bbe1;background-color:#d9edf7}.badge.options{color:#70bbe1;background-color:#d9edf7}.badge.put{color:#f0db70;background-color:#fcf8e3}.badge.patch{color:#f0db70;background-color:#fcf8e3}.badge.post{color:#93cd7c;background-color:#dff0d8}.badge.delete{color:#ce8383;background-color:#f2dede}.collapse-button{float:right}.collapse-button .close{display:none;color:#428bca;cursor:pointer}.collapse-button .open{color:#428bca;cursor:pointer}.collapse-button.show .close{display:inline}.collapse-button.show .open{display:none}.collapse-content{max-height:0;overflow:hidden;transition:max-height .3s ease-in-out}nav{width:220px}.container{max-width:940px;margin-left:auto;margin-right:auto}.container .row .content{margin-left:244px;width:696px}.container .row:after{content:'';display:block;clear:both}.container-fluid nav{width:22%}.container-fluid .row .content{margin-left:24%}.container-fluid.triple nav{width:16.5%;padding-right:1px}.container-fluid.triple .row .content{position:relative;margin-left:16.5%;padding-left:24px}.middle:before,.middle:after{content:'';display:table}.middle:after{clear:both}.middle{box-sizing:border-box;width:51.5%;padding-right:12px}.right{box-sizing:border-box;float:right;width:48.5%;padding-left:12px}.right a{color:#428bca}.right h1,.right h2,.right h3,.right h4,.right h5,.right p,.right div{color:white}.right pre{background-color:#1d1f21;border:1px solid #1d1f21}.right pre code{color:#c5c8c6}.right .description{margin-top:12px}.triple .resource-heading{font-size:125%}.definition{margin-top:12px;margin-bottom:12px}.definition .method{font-weight:bold}.definition .method.get{color:#2e8ab8}.definition .method.head{color:#2e8ab8}.definition .method.options{color:#2e8ab8}.definition .method.post{color:#56b82e}.definition .method.put{color:#b8a22e}.definition .method.patch{color:#b8a22e}.definition .method.delete{color:#b82e2e}.definition .uri{word-break:break-all;word-wrap:break-word}.definition .hostname{opacity:.5}.example-names{background-color:#eee;padding:12px;border-radius:6px}.example-names .tab-button{cursor:pointer;color:black;border:1px solid #ddd;padding:6px;margin-left:12px}.example-names .tab-button.active{background-color:#d5d5d5}.right .example-names{background-color:#444}.right .example-names .tab-button{color:white;border:1px solid #666;border-radius:6px}.right .example-names .tab-button.active{background-color:#5e5e5e}#nav-background{position:fixed;left:0;top:0;bottom:0;width:16.5%;padding-right:14.4px;background-color:#fbfbfb;border-right:1px solid #f0f0f0;z-index:-1}#right-panel-background{position:absolute;right:-12px;top:-12px;bottom:-12px;width:48.6%;background-color:#333;z-index:-1}@media (max-width:1200px){nav{width:198px}.container{max-width:840px}.container .row .content{margin-left:224px;width:606px}}@media (max-width:992px){nav{width:169.4px}.container{max-width:720px}.container .row .content{margin-left:194px;width:526px}}@media (max-width:768px){nav{display:none}.container{width:95%;max-width:none}.container .row .content,.container-fluid .row .content,.container-fluid.triple .row .content{margin-left:auto;margin-right:auto;width:95%}#nav-background{display:none}#right-panel-background{width:48.6%}}.back-to-top{position:fixed;z-index:1;bottom:0;right:24px;padding:4px 8px;color:rgba(0,0,0,0.5);background-color:#f2f2f2;text-decoration:none !important;border-top:1px solid #d9d9d9;border-left:1px solid #d9d9d9;border-right:1px solid #d9d9d9;border-top-left-radius:3px;border-top-right-radius:3px}.resource-group{padding:12px;margin-bottom:12px;background-color:white;border:1px solid #d9d9d9;border-radius:6px}.resource-group h2.group-heading,.resource-group .heading a{padding:12px;margin:-12px -12px 12px -12px;background-color:#f2f2f2;border-bottom:1px solid #d9d9d9;border-top-left-radius:6px;border-top-right-radius:6px;white-space:nowrap;text-overflow:ellipsis;overflow:hidden}.triple .content .resource-group{padding:0;border:none}.triple .content .resource-group h2.group-heading,.triple .content .resource-group .heading a{margin:0 0 12px 0;border:1px solid #d9d9d9}nav .resource-group .heading a{padding:12px;margin-bottom:0}nav .resource-group .collapse-content{padding:0}.action{margin-bottom:12px;padding:12px 12px 0 12px;overflow:hidden;border:1px solid transparent;border-radius:6px}.action h4.action-heading{padding:6px 12px;margin:-12px -12px 12px -12px;border-bottom:1px solid transparent;border-top-left-radius:6px;border-top-right-radius:6px;overflow:hidden}.action h4.action-heading .name{float:right;font-weight:normal;padding:6px 0}.action h4.action-heading .method{padding:6px 12px;margin-right:12px;border-radius:3px;display:inline-block}.action h4.action-heading .method.get{color:#fff;background-color:#337ab7}.action h4.action-heading .method.head{color:#fff;background-color:#337ab7}.action h4.action-heading .method.options{color:#fff;background-color:#337ab7}.action h4.action-heading .method.put{color:#fff;background-color:#ed9c28}.action h4.action-heading .method.patch{color:#fff;background-color:#ed9c28}.action h4.action-heading .method.post{color:#fff;background-color:#5cb85c}.action h4.action-heading .method.delete{color:#fff;background-color:#d9534f}.action h4.action-heading code{color:#444;background-color:#f5f5f5;border-color:#cfcfcf;font-weight:normal;word-break:break-all;display:inline-block;margin-top:2px}.action dl.inner{padding-bottom:2px}.action .title{border-bottom:1px solid white;margin:0 -12px -1px -12px;padding:12px}.action.get{border-color:#bce8f1}.action.get h4.action-heading{color:#337ab7;background:#d9edf7;border-bottom-color:#bce8f1}.action.head{border-color:#bce8f1}.action.head h4.action-heading{color:#337ab7;background:#d9edf7;border-bottom-color:#bce8f1}.action.options{border-color:#bce8f1}.action.options h4.action-heading{color:#337ab7;background:#d9edf7;border-bottom-color:#bce8f1}.action.post{border-color:#d6e9c6}.action.post h4.action-heading{color:#5cb85c;background:#dff0d8;border-bottom-color:#d6e9c6}.action.put{border-color:#faebcc}.action.put h4.action-heading{color:#ed9c28;background:#fcf8e3;border-bottom-color:#faebcc}.action.patch{border-color:#faebcc}.action.patch h4.action-heading{color:#ed9c28;background:#fcf8e3;border-bottom-color:#faebcc}.action.delete{border-color:#ebccd1}.action.delete h4.action-heading{color:#d9534f;background:#f2dede;border-bottom-color:#ebccd1}</style></head><body class="preload"><a href="#top" class="text-muted back-to-top"><i class="fa fa-toggle-up"></i>&nbsp;Back to top</a><div class="container"><div class="row"><nav><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#認証">認証</a></div><div class="collapse-content"><ul><li><a href="#header-認証について">認証について</a></li><li><a href="#header-get">GET</a></li><li><a href="#header-概要">概要</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#在庫データ">在庫データ</a></div><div class="collapse-content"><ul><li><a href="#在庫データ-在庫データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>在庫データ一覧取得</a></li><li><a href="#在庫データ-在庫データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>在庫データ作成</a></li><li><a href="#在庫データ-在庫データ個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>在庫データ個別取得</a></li><li><a href="#在庫データ-在庫データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>在庫データ更新</a></li><li><a href="#在庫データ-在庫データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>在庫データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#出庫データ">出庫データ</a></div><div class="collapse-content"><ul><li><a href="#出庫データ-出庫データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>出庫データ一覧取得</a></li><li><a href="#出庫データ-出庫データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>出庫データ作成</a></li><li><a href="#出庫データ-出庫データ個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>出庫データ個別取得</a></li><li><a href="#出庫データ-出庫データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>出庫データ更新</a></li><li><a href="#出庫データ-出庫データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>出庫データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#入庫データ">入庫データ</a></div><div class="collapse-content"><ul><li><a href="#入庫データ-入庫データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>入庫データ一覧取得</a></li><li><a href="#入庫データ-入庫データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>入庫データ作成</a></li><li><a href="#入庫データ-入庫データ個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>入庫データ個別取得</a></li><li><a href="#入庫データ-入庫データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>入庫データ更新</a></li><li><a href="#入庫データ-入庫データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>入庫データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#取引先データ">取引先データ</a></div><div class="collapse-content"><ul><li><a href="#取引先データ-取引先データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>取引先データ一覧取得</a></li><li><a href="#取引先データ-取引先データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>取引先データ作成</a></li><li><a href="#取引先データ-取引先データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>取引先データ更新</a></li><li><a href="#取引先データ-取引先データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>取引先データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#発送元データ">発送元データ</a></div><div class="collapse-content"><ul><li><a href="#発送元データ-発送元データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>発送元データ一覧取得</a></li></ul></div></div><p style="text-align: center; word-wrap: break-word;"><a href="https://web.zaico.co.jp">https://web.zaico.co.jp</a></p></nav><div class="content"><header><h1 id="top">zaico API Document</h1></header><p>このドキュメントはZAICO APIの機能と使うために必要なパラメータなどを説明するものです。<br>
 2022年12月14日更新</p>
 <section id="認証" class="resource-group"><h2 class="group-heading">認証 <a href="#認証" class="permalink">&para;</a></h2><h2 id="header-認証について">認証について <a class="permalink" href="#header-認証について" aria-hidden="true">¶</a></h2>
 <h3 id="header-get">GET <a class="permalink" href="#header-get" aria-hidden="true">¶</a></h3>
@@ -942,6 +942,23 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 <li>etc : 摘要・備考</li>
 </ul>
 </li>
+<li>shipping_instruction : 発送情報（フルプラン、かつ設定されている場合のみ表示されます）
+<ul>
+<li>to_name : 宛名</li>
+<li>to_name_postfix : 敬称</li>
+<li>to_zip : 郵便番号</li>
+<li>to_address : 住所</li>
+<li>building_name : 建物名・部屋番号</li>
+<li>to_phone_number : 電話番号</li>
+<li>shipping_client_id : 発送元ID</li>
+<li>invoice_type_name : 便指定</li>
+<li>product_name_on_invoice : 品名</li>
+<li>freight_handling : 荷扱い</li>
+<li>freight_handling2 : 荷扱い</li>
+<li>arrival_date : 希望お届け日</li>
+<li>arrival_hour : 希望お届け時間帯</li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -979,7 +996,22 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
         "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-literal">null</span></span>,
         "<span class="hljs-attribute">etc</span>": <span class="hljs-value"><span class="hljs-string">""</span>
       </span>}
-    ]
+    ]</span>,
+    "<span class="hljs-attribute">shipping_instruction</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">to_name</span>": <span class="hljs-value"><span class="hljs-string">"在庫商会"</span></span>,
+      "<span class="hljs-attribute">to_name_postfix</span>": <span class="hljs-value"><span class="hljs-string">"御中"</span></span>,
+      "<span class="hljs-attribute">to_zip</span>": <span class="hljs-value"><span class="hljs-string">"1000101"</span></span>,
+      "<span class="hljs-attribute">to_address</span>": <span class="hljs-value"><span class="hljs-string">"東京都大島町元町"</span></span>,
+      "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"ザイコ工場"</span></span>,
+      "<span class="hljs-attribute">to_phone_number</span>": <span class="hljs-value"><span class="hljs-string">"0312341234"</span></span>,
+      "<span class="hljs-attribute">shipping_client_id</span>": <span class="hljs-value"><span class="hljs-number">123</span></span>,
+      "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value"><span class="hljs-string">"宅急便（ヤマト）"</span></span>,
+      "<span class="hljs-attribute">product_name_on_invoice</span>": <span class="hljs-value"><span class="hljs-string">"化学薬品"</span></span>,
+      "<span class="hljs-attribute">freight_handling</span>": <span class="hljs-value"><span class="hljs-string">"ワレ物注意"</span></span>,
+      "<span class="hljs-attribute">freight_handling2</span>": <span class="hljs-value"><span class="hljs-string">"下載厳禁"</span></span>,
+      "<span class="hljs-attribute">arrival_date</span>": <span class="hljs-value"><span class="hljs-string">"2023-10-31"</span></span>,
+      "<span class="hljs-attribute">arrival_hour</span>": <span class="hljs-value"><span class="hljs-string">"14〜16時"</span>
+    </span>}
   </span>},
   {
     "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">11</span></span>,
@@ -1057,6 +1089,23 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 </li>
 </ul>
 </li>
+<li>shipping_instruction : 発送情報（フルプランのみ設定できます）
+<ul>
+<li>to_name : 宛名</li>
+<li>to_name_postfix : 敬称</li>
+<li>to_zip : 郵便番号</li>
+<li>to_address : 住所</li>
+<li>building_name : 建物名・部屋番号</li>
+<li>to_phone_number : 電話番号</li>
+<li>shipping_client_id : 発送元ID</li>
+<li>invoice_type_name : 便指定</li>
+<li>product_name_on_invoice : 品名</li>
+<li>freight_handling : 荷扱い</li>
+<li>freight_handling2 : 荷扱い</li>
+<li>arrival_date : 希望お届け日</li>
+<li>arrival_hour : 希望お届け時間帯</li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -1072,7 +1121,22 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
       "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span>
     </span>}
-  ]
+  ]</span>,
+  "<span class="hljs-attribute">shipping_instruction</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">to_name</span>": <span class="hljs-value"><span class="hljs-string">"在庫商会"</span></span>,
+    "<span class="hljs-attribute">to_name_postfix</span>": <span class="hljs-value"><span class="hljs-string">"御中"</span></span>,
+    "<span class="hljs-attribute">to_zip</span>": <span class="hljs-value"><span class="hljs-string">"1000101"</span></span>,
+    "<span class="hljs-attribute">to_address</span>": <span class="hljs-value"><span class="hljs-string">"東京都大島町元町"</span></span>,
+    "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"ザイコ工場"</span></span>,
+    "<span class="hljs-attribute">to_phone_number</span>": <span class="hljs-value"><span class="hljs-string">"0312341234"</span></span>,
+    "<span class="hljs-attribute">shipping_client_id</span>": <span class="hljs-value"><span class="hljs-number">123</span></span>,
+    "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value"><span class="hljs-string">"宅急便（ヤマト）"</span></span>,
+    "<span class="hljs-attribute">product_name_on_invoice</span>": <span class="hljs-value"><span class="hljs-string">"化学薬品"</span></span>,
+    "<span class="hljs-attribute">freight_handling</span>": <span class="hljs-value"><span class="hljs-string">"ワレ物注意"</span></span>,
+    "<span class="hljs-attribute">freight_handling2</span>": <span class="hljs-value"><span class="hljs-string">"下載厳禁"</span></span>,
+    "<span class="hljs-attribute">arrival_date</span>": <span class="hljs-value"><span class="hljs-string">"2023-10-31"</span></span>,
+    "<span class="hljs-attribute">arrival_hour</span>": <span class="hljs-value"><span class="hljs-string">"14〜16時"</span>
+  </span>}
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
@@ -1095,6 +1159,63 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     </span>}</span>,
     "<span class="hljs-attribute">deliveries</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">shipping_instruction</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">to_name</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"宛名"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">to_name_postfix</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"敬称"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">to_zip</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"郵便番号"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">to_address</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"住所"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">building_name</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"建物名・部屋番号"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">to_phone_number</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"電話番号"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">shipping_client_id</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発送元ID"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"便指定"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">product_name_on_invoice</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"品名"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">freight_handling</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"荷扱い"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">freight_handling2</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"荷扱い"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">arrival_date</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"希望お届け日"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">arrival_hour</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"希望お届け時間帯"</span>
+        </span>}
+      </span>}
     </span>}
   </span>}</span>,
   "<span class="hljs-attribute">required</span>": <span class="hljs-value">[
@@ -1194,6 +1315,23 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 <li>etc: 摘要・備考</li>
 </ul>
 </li>
+<li>shipping_instruction : 発送情報（フルプラン、かつ設定されている場合のみ表示されます）
+<ul>
+<li>to_name : 宛名</li>
+<li>to_name_postfix : 敬称</li>
+<li>to_zip : 郵便番号</li>
+<li>to_address : 住所</li>
+<li>building_name : 建物名・部屋番号</li>
+<li>to_phone_number : 電話番号</li>
+<li>shipping_client_id : 発送元ID</li>
+<li>invoice_type_name : 便指定</li>
+<li>product_name_on_invoice : 品名</li>
+<li>freight_handling : 荷扱い</li>
+<li>freight_handling2 : 荷扱い</li>
+<li>arrival_date : 希望お届け日</li>
+<li>arrival_hour : 希望お届け時間帯</li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -1207,31 +1345,45 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
   "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
   "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
   "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span></span>,
-  "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value">{
-    "<span class="hljs-attribute">deliveries</span>": <span class="hljs-value">[
-      {
-        "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
-        "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"掃除機"</span></span>,
-        "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
-        "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"台"</span></span>,
-        "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
-        "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"completed_delivery"</span></span>,
-        "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
-        "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-literal">null</span></span>,
-        "<span class="hljs-attribute">etc</span>": <span class="hljs-value"><span class="hljs-string">"白色"</span>
-      </span>},
-      {
-        "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">2</span></span>,
-        "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"テレビ"</span></span>,
-        "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
-        "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"台"</span></span>,
-        "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
-        "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"completed_delivery"</span></span>,
-        "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
-        "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
-        "<span class="hljs-attribute">etc</span>": <span class="hljs-value"><span class="hljs-string">""</span>
-      </span>}
-    ]
+  "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span></span>,
+  "<span class="hljs-attribute">deliveries</span>": <span class="hljs-value">[
+    {
+      "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+      "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"掃除機"</span></span>,
+      "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
+      "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"台"</span></span>,
+      "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
+      "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"completed_delivery"</span></span>,
+      "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
+      "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-literal">null</span></span>,
+      "<span class="hljs-attribute">etc</span>": <span class="hljs-value"><span class="hljs-string">"白色"</span>
+    </span>},
+    {
+      "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">2</span></span>,
+      "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"テレビ"</span></span>,
+      "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
+      "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"台"</span></span>,
+      "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
+      "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"completed_delivery"</span></span>,
+      "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
+      "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
+      "<span class="hljs-attribute">etc</span>": <span class="hljs-value"><span class="hljs-string">""</span>
+    </span>}
+  ]</span>,
+  "<span class="hljs-attribute">shipping_instruction</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">to_name</span>": <span class="hljs-value"><span class="hljs-string">"在庫商会"</span></span>,
+    "<span class="hljs-attribute">to_name_postfix</span>": <span class="hljs-value"><span class="hljs-string">"御中"</span></span>,
+    "<span class="hljs-attribute">to_zip</span>": <span class="hljs-value"><span class="hljs-string">"1000101"</span></span>,
+    "<span class="hljs-attribute">to_address</span>": <span class="hljs-value"><span class="hljs-string">"東京都大島町元町"</span></span>,
+    "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"ザイコ工場"</span></span>,
+    "<span class="hljs-attribute">to_phone_number</span>": <span class="hljs-value"><span class="hljs-string">"0312341234"</span></span>,
+    "<span class="hljs-attribute">shipping_client_id</span>": <span class="hljs-value"><span class="hljs-number">123</span></span>,
+    "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value"><span class="hljs-string">"宅急便（ヤマト）"</span></span>,
+    "<span class="hljs-attribute">product_name_on_invoice</span>": <span class="hljs-value"><span class="hljs-string">"化学薬品"</span></span>,
+    "<span class="hljs-attribute">freight_handling</span>": <span class="hljs-value"><span class="hljs-string">"ワレ物注意"</span></span>,
+    "<span class="hljs-attribute">freight_handling2</span>": <span class="hljs-value"><span class="hljs-string">"下載厳禁"</span></span>,
+    "<span class="hljs-attribute">arrival_date</span>": <span class="hljs-value"><span class="hljs-string">"2023-10-31"</span></span>,
+    "<span class="hljs-attribute">arrival_hour</span>": <span class="hljs-value"><span class="hljs-string">"14〜16時"</span>
   </span>}
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
@@ -1266,92 +1418,147 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
     </span>}</span>,
     "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">deliveries</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span></span>,
+      "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+          "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">title</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"物品名"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"出庫数量"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">unit</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"納品単価"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value">[
+                <span class="hljs-string">"string"</span>,
+                <span class="hljs-string">"null"</span>
+              ]
+            </span>}</span>,
+            "<span class="hljs-attribute">etc</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"摘要・備考"</span>
+            </span>}
+          </span>}
+        </span>},
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+          "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">title</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"物品名"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"出庫数量"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">unit</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"納品単価"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value">[
+                <span class="hljs-string">"string"</span>,
+                <span class="hljs-string">"null"</span>
+              ]
+            </span>}</span>,
+            "<span class="hljs-attribute">etc</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"摘要・備考"</span>
+            </span>}
+          </span>}
+        </span>}
+      ]
+    </span>}</span>,
+    "<span class="hljs-attribute">shipping_instruction</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
       "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
-        "<span class="hljs-attribute">deliveries</span>": <span class="hljs-value">{
-          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span></span>,
-          "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
-            {
-              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
-              "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
-                "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">title</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
-                  "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"物品名"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
-                  "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"出庫数量"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">unit</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
-                  "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
-                  "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"納品単価"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value">[
-                    <span class="hljs-string">"string"</span>,
-                    <span class="hljs-string">"null"</span>
-                  ]
-                </span>}</span>,
-                "<span class="hljs-attribute">etc</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
-                  "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"摘要・備考"</span>
-                </span>}
-              </span>}
-            </span>},
-            {
-              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
-              "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
-                "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">title</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
-                  "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"物品名"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
-                  "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"出庫数量"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">unit</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
-                  "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
-                  "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"納品単価"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
-                </span>}</span>,
-                "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value">[
-                    <span class="hljs-string">"string"</span>,
-                    <span class="hljs-string">"null"</span>
-                  ]
-                </span>}</span>,
-                "<span class="hljs-attribute">etc</span>": <span class="hljs-value">{
-                  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
-                  "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"摘要・備考"</span>
-                </span>}
-              </span>}
-            </span>}
-          ]
+        "<span class="hljs-attribute">to_name</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"宛名"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">to_name_postfix</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"敬称"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">to_zip</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"郵便番号"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">to_address</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"住所"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">building_name</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"建物名・部屋番号"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">to_phone_number</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"電話番号"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">shipping_client_id</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発送元ID"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"便指定"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">product_name_on_invoice</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"品名"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">freight_handling</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"荷扱い"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">freight_handling2</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"荷扱い"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">arrival_date</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"希望お届け日"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">arrival_hour</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"希望お届け時間帯"</span>
         </span>}
       </span>}
     </span>}
@@ -1394,6 +1601,23 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 </li>
 </ul>
 </li>
+<li>shipping_instruction : 発送情報（フルプランのみ設定できます）
+<ul>
+<li>to_name : 宛名</li>
+<li>to_name_postfix : 敬称</li>
+<li>to_zip : 郵便番号</li>
+<li>to_address : 住所</li>
+<li>building_name : 建物名・部屋番号</li>
+<li>to_phone_number : 電話番号</li>
+<li>shipping_client_id : 発送元ID</li>
+<li>invoice_type_name : 便指定</li>
+<li>product_name_on_invoice : 品名</li>
+<li>freight_handling : 荷扱い</li>
+<li>freight_handling2 : 荷扱い</li>
+<li>arrival_date : 希望お届け日</li>
+<li>arrival_hour : 希望お届け時間帯</li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -1417,7 +1641,22 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"before_delivery"</span></span>,
       "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-11-11"</span>
     </span>}
-  ]
+  ]</span>,
+  "<span class="hljs-attribute">shipping_instruction</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">to_name</span>": <span class="hljs-value"><span class="hljs-string">"在庫商会"</span></span>,
+    "<span class="hljs-attribute">to_name_postfix</span>": <span class="hljs-value"><span class="hljs-string">"御中"</span></span>,
+    "<span class="hljs-attribute">to_zip</span>": <span class="hljs-value"><span class="hljs-string">"1000101"</span></span>,
+    "<span class="hljs-attribute">to_address</span>": <span class="hljs-value"><span class="hljs-string">"東京都大島町元町"</span></span>,
+    "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"ザイコ工場"</span></span>,
+    "<span class="hljs-attribute">to_phone_number</span>": <span class="hljs-value"><span class="hljs-string">"0312341234"</span></span>,
+    "<span class="hljs-attribute">shipping_client_id</span>": <span class="hljs-value"><span class="hljs-number">123</span></span>,
+    "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value"><span class="hljs-string">"宅急便（ヤマト）"</span></span>,
+    "<span class="hljs-attribute">product_name_on_invoice</span>": <span class="hljs-value"><span class="hljs-string">"化学薬品"</span></span>,
+    "<span class="hljs-attribute">freight_handling</span>": <span class="hljs-value"><span class="hljs-string">"ワレ物注意"</span></span>,
+    "<span class="hljs-attribute">freight_handling2</span>": <span class="hljs-value"><span class="hljs-string">"下載厳禁"</span></span>,
+    "<span class="hljs-attribute">arrival_date</span>": <span class="hljs-value"><span class="hljs-string">"2023-10-31"</span></span>,
+    "<span class="hljs-attribute">arrival_hour</span>": <span class="hljs-value"><span class="hljs-string">"14〜16時"</span>
+  </span>}
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
@@ -1432,6 +1671,63 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     </span>}</span>,
     "<span class="hljs-attribute">deliveries</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">shipping_instruction</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">to_name</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"宛名"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">to_name_postfix</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"敬称"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">to_zip</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"郵便番号"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">to_address</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"住所"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">building_name</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"建物名・部屋番号"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">to_phone_number</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"電話番号"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">shipping_client_id</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発送元ID"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"便指定"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">product_name_on_invoice</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"品名"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">freight_handling</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"荷扱い"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">freight_handling2</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"荷扱い"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">arrival_date</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"希望お届け日"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">arrival_hour</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"希望お届け時間帯"</span>
+        </span>}
+      </span>}
     </span>}
   </span>}</span>,
   "<span class="hljs-attribute">required</span>": <span class="hljs-value">[
@@ -2520,7 +2816,45 @@ https://web.zaico.co.jp/api/v1/customers?page=1</code></pre>
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 26 May 2023</p><script>/* eslint-env browser */
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="発送元データ" class="resource-group"><h2 class="group-heading">発送元データ <a href="#発送元データ" class="permalink">&para;</a></h2><div id="発送元データ-発送元データ一覧取得" class="resource"><h3 class="resource-heading">発送元データ一覧取得 <a href="#発送元データ-発送元データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="発送元データ-発送元データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#発送元データ-発送元データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/shipping_clients/</code></h4><h4 id="header-処理概要-19">処理概要 <a class="permalink" href="#header-処理概要-19" aria-hidden="true">¶</a></h4>
+<ul>
+<li>
+<p>フルプランのみ参照できます。</p>
+</li>
+<li>
+<p>自分のアカウントに登録されている発送元データのすべてを返します</p>
+</li>
+<li>
+<p>発送元データが1件も無い場合は、空の配列を返します</p>
+</li>
+<li>
+<p>発送元データが1000件以上ある場合はページネーションで分割され、1000件ごと発送元データを返します</p>
+</li>
+<li>
+<p>任意のページを取得するにはURLにクエリ「page=」をつけることで取得できます。</p>
+</li>
+<li>
+<p>ページ情報はHTTPヘッダ&quot;Link&quot;に最初のページ、前のページ、次のページ、最後のページそれぞれ,(カンマ)で区切られ返されます。最初のページでは「前のページ」、最後のページでは「次のページ」項目は表示されません</p>
+</li>
+<li>
+<p>Link, Total-Countヘッダは発送元一覧でのみ返されます</p>
+<pre><code class="language-http">Ref：
+https://web.zaico.co.jp/api/v1/shipping_clients?page=1</code></pre>
+</li>
+</ul>
+<h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/shipping_clients/</span></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span><br><span class="hljs-attribute">Link</span>: <span class="hljs-string">&lt;https://web.zaico.co.jp/api/v1/shipping_clients?page=1&gt;; rel="first", &lt;https://web.zaico.co.jp/api/v1/shipping_clients?page=1&gt;; rel="last"</span><br><span class="hljs-attribute">Total-Count</span>: <span class="hljs-string">発送元データ件数</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>[
+  {
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+    "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"発送元A"</span></span>,
+    "<span class="hljs-attribute">zip</span>": <span class="hljs-value"><span class="hljs-string">"1234567"</span></span>,
+    "<span class="hljs-attribute">address</span>": <span class="hljs-value"><span class="hljs-string">"東京都港区"</span></span>,
+    "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"港ビル"</span></span>,
+    "<span class="hljs-attribute">phone_number</span>": <span class="hljs-value"><span class="hljs-string">"08012345678"</span>
+  </span>}
+]</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 07 Oct 2023</p><script>/* eslint-env browser */
 /* eslint quotes: [2, "single"] */
 'use strict';
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -950,7 +950,16 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 <li>to_address : 住所</li>
 <li>building_name : 建物名・部屋番号</li>
 <li>to_phone_number : 電話番号</li>
-<li>shipping_client_id : 発送元ID</li>
+<li>shipping_client : 発送元
+<ul>
+<li>id : 発送元ID</li>
+<li>name : 名前/会社名</li>
+<li>zip : 郵便番号</li>
+<li>address : 住所</li>
+<li>building_name : 建物名・部屋番号</li>
+<li>phone_number : 電話番号</li>
+</ul>
+</li>
 <li>invoice_type_name : 便指定</li>
 <li>product_name_on_invoice : 品名</li>
 <li>freight_handling : 荷扱い</li>
@@ -1004,8 +1013,15 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">to_address</span>": <span class="hljs-value"><span class="hljs-string">"東京都大島町元町"</span></span>,
       "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"ザイコ工場"</span></span>,
       "<span class="hljs-attribute">to_phone_number</span>": <span class="hljs-value"><span class="hljs-string">"0312341234"</span></span>,
-      "<span class="hljs-attribute">shipping_client_id</span>": <span class="hljs-value"><span class="hljs-number">123</span></span>,
-      "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value"><span class="hljs-string">"宅急便（ヤマト）"</span></span>,
+      "<span class="hljs-attribute">shipping_client</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+        "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"発送元A"</span></span>,
+        "<span class="hljs-attribute">zip</span>": <span class="hljs-value"><span class="hljs-string">"1234567"</span></span>,
+        "<span class="hljs-attribute">address</span>": <span class="hljs-value"><span class="hljs-string">"東京都港区"</span></span>,
+        "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"港ビル"</span></span>,
+        "<span class="hljs-attribute">phone_number</span>": <span class="hljs-value"><span class="hljs-string">"08012345678"</span>
+      </span>}</span>,
+      "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value"><span class="hljs-string">"ヤマト 発払い"</span></span>,
       "<span class="hljs-attribute">product_name_on_invoice</span>": <span class="hljs-value"><span class="hljs-string">"化学薬品"</span></span>,
       "<span class="hljs-attribute">freight_handling</span>": <span class="hljs-value"><span class="hljs-string">"ワレ物注意"</span></span>,
       "<span class="hljs-attribute">freight_handling2</span>": <span class="hljs-value"><span class="hljs-string">"下載厳禁"</span></span>,
@@ -1098,12 +1114,28 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 <li>building_name : 建物名・部屋番号</li>
 <li>to_phone_number : 電話番号</li>
 <li>shipping_client_id : 発送元ID</li>
-<li>invoice_type_name : 便指定</li>
+<li>invoice_type_name : 便指定
+<ul>
+<li>指定可能な値 : <code>ヤマト 発払い</code> <code>ヤマト DM便</code> <code>ヤマト 着払い</code> <code>ヤマト ネコポス</code> <code>佐川 元払</code> <code>佐川 着払</code> <code>ゆうパケット</code> <code>クリックポスト</code> <code>その他</code></li>
+</ul>
+</li>
 <li>product_name_on_invoice : 品名</li>
-<li>freight_handling : 荷扱い</li>
-<li>freight_handling2 : 荷扱い</li>
+<li>freight_handling : 荷扱い
+<ul>
+<li>指定可能な値 : <code>指定なし</code> <code>ワレ物注意</code> <code>下載厳禁</code> <code>天地無用</code> <code>精密機器</code> <code>ナマモノ</code> <code>水濡厳禁</code> <code>取扱注意</code> （※「取扱注意」は佐川のみ）</li>
+</ul>
+</li>
+<li>freight_handling2 : 荷扱い
+<ul>
+<li>指定可能な値 : <code>指定なし</code> <code>ワレ物注意</code> <code>下載厳禁</code> <code>天地無用</code> <code>精密機器</code> <code>ナマモノ</code> <code>水濡厳禁</code> <code>取扱注意</code> （※「取扱注意」は佐川のみ）</li>
+</ul>
+</li>
 <li>arrival_date : 希望お届け日</li>
-<li>arrival_hour : 希望お届け時間帯</li>
+<li>arrival_hour : 希望お届け時間帯
+<ul>
+<li>指定可能な値 : <code>指定なし</code> <code>午前中</code> <code>14〜16時</code> <code>16〜18時</code> <code>18〜20時</code> <code>19〜21時</code></li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -1130,7 +1162,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"ザイコ工場"</span></span>,
     "<span class="hljs-attribute">to_phone_number</span>": <span class="hljs-value"><span class="hljs-string">"0312341234"</span></span>,
     "<span class="hljs-attribute">shipping_client_id</span>": <span class="hljs-value"><span class="hljs-number">123</span></span>,
-    "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value"><span class="hljs-string">"宅急便（ヤマト）"</span></span>,
+    "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value"><span class="hljs-string">"ヤマト 発払い"</span></span>,
     "<span class="hljs-attribute">product_name_on_invoice</span>": <span class="hljs-value"><span class="hljs-string">"化学薬品"</span></span>,
     "<span class="hljs-attribute">freight_handling</span>": <span class="hljs-value"><span class="hljs-string">"ワレ物注意"</span></span>,
     "<span class="hljs-attribute">freight_handling2</span>": <span class="hljs-value"><span class="hljs-string">"下載厳禁"</span></span>,
@@ -1323,7 +1355,16 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 <li>to_address : 住所</li>
 <li>building_name : 建物名・部屋番号</li>
 <li>to_phone_number : 電話番号</li>
-<li>shipping_client_id : 発送元ID</li>
+<li>shipping_client : 発送元
+<ul>
+<li>id : 発送元ID</li>
+<li>name : 名前/会社名</li>
+<li>zip : 郵便番号</li>
+<li>address : 住所</li>
+<li>building_name : 建物名・部屋番号</li>
+<li>phone_number : 電話番号</li>
+</ul>
+</li>
 <li>invoice_type_name : 便指定</li>
 <li>product_name_on_invoice : 品名</li>
 <li>freight_handling : 荷扱い</li>
@@ -1377,8 +1418,15 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">to_address</span>": <span class="hljs-value"><span class="hljs-string">"東京都大島町元町"</span></span>,
     "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"ザイコ工場"</span></span>,
     "<span class="hljs-attribute">to_phone_number</span>": <span class="hljs-value"><span class="hljs-string">"0312341234"</span></span>,
-    "<span class="hljs-attribute">shipping_client_id</span>": <span class="hljs-value"><span class="hljs-number">123</span></span>,
-    "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value"><span class="hljs-string">"宅急便（ヤマト）"</span></span>,
+    "<span class="hljs-attribute">shipping_client</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+      "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"発送元A"</span></span>,
+      "<span class="hljs-attribute">zip</span>": <span class="hljs-value"><span class="hljs-string">"1234567"</span></span>,
+      "<span class="hljs-attribute">address</span>": <span class="hljs-value"><span class="hljs-string">"東京都港区"</span></span>,
+      "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"港ビル"</span></span>,
+      "<span class="hljs-attribute">phone_number</span>": <span class="hljs-value"><span class="hljs-string">"08012345678"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value"><span class="hljs-string">"ヤマト 発払い"</span></span>,
     "<span class="hljs-attribute">product_name_on_invoice</span>": <span class="hljs-value"><span class="hljs-string">"化学薬品"</span></span>,
     "<span class="hljs-attribute">freight_handling</span>": <span class="hljs-value"><span class="hljs-string">"ワレ物注意"</span></span>,
     "<span class="hljs-attribute">freight_handling2</span>": <span class="hljs-value"><span class="hljs-string">"下載厳禁"</span></span>,
@@ -1532,9 +1580,35 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
           "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"電話番号"</span>
         </span>}</span>,
-        "<span class="hljs-attribute">shipping_client_id</span>": <span class="hljs-value">{
-          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
-          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発送元ID"</span>
+        "<span class="hljs-attribute">shipping_client</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+          "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">id</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"レコードID"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">name</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"名前/会社名"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">zip</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"郵便番号"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">address</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"住所"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">building_name</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"建物名・部屋番号"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">phone_number</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"電話番号"</span>
+            </span>}
+          </span>}</span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発送元"</span>
         </span>}</span>,
         "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
@@ -1610,12 +1684,28 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 <li>building_name : 建物名・部屋番号</li>
 <li>to_phone_number : 電話番号</li>
 <li>shipping_client_id : 発送元ID</li>
-<li>invoice_type_name : 便指定</li>
+<li>invoice_type_name : 便指定
+<ul>
+<li>指定可能な値 : <code>ヤマト 発払い</code> <code>ヤマト DM便</code> <code>ヤマト 着払い</code> <code>ヤマト ネコポス</code> <code>佐川 元払</code> <code>佐川 着払</code> <code>ゆうパケット</code> <code>クリックポスト</code> <code>その他</code></li>
+</ul>
+</li>
 <li>product_name_on_invoice : 品名</li>
-<li>freight_handling : 荷扱い</li>
-<li>freight_handling2 : 荷扱い</li>
+<li>freight_handling : 荷扱い
+<ul>
+<li>指定可能な値 : <code>指定なし</code> <code>ワレ物注意</code> <code>下載厳禁</code> <code>天地無用</code> <code>精密機器</code> <code>ナマモノ</code> <code>水濡厳禁</code> <code>取扱注意</code> （※「取扱注意」は佐川のみ）</li>
+</ul>
+</li>
+<li>freight_handling2 : 荷扱い
+<ul>
+<li>指定可能な値 : <code>指定なし</code> <code>ワレ物注意</code> <code>下載厳禁</code> <code>天地無用</code> <code>精密機器</code> <code>ナマモノ</code> <code>水濡厳禁</code> <code>取扱注意</code> （※「取扱注意」は佐川のみ）</li>
+</ul>
+</li>
 <li>arrival_date : 希望お届け日</li>
-<li>arrival_hour : 希望お届け時間帯</li>
+<li>arrival_hour : 希望お届け時間帯
+<ul>
+<li>指定可能な値 : <code>指定なし</code> <code>午前中</code> <code>14〜16時</code> <code>16〜18時</code> <code>18〜20時</code> <code>19〜21時</code></li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -1650,7 +1740,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"ザイコ工場"</span></span>,
     "<span class="hljs-attribute">to_phone_number</span>": <span class="hljs-value"><span class="hljs-string">"0312341234"</span></span>,
     "<span class="hljs-attribute">shipping_client_id</span>": <span class="hljs-value"><span class="hljs-number">123</span></span>,
-    "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value"><span class="hljs-string">"宅急便（ヤマト）"</span></span>,
+    "<span class="hljs-attribute">invoice_type_name</span>": <span class="hljs-value"><span class="hljs-string">"ヤマト 発払い"</span></span>,
     "<span class="hljs-attribute">product_name_on_invoice</span>": <span class="hljs-value"><span class="hljs-string">"化学薬品"</span></span>,
     "<span class="hljs-attribute">freight_handling</span>": <span class="hljs-value"><span class="hljs-string">"ワレ物注意"</span></span>,
     "<span class="hljs-attribute">freight_handling2</span>": <span class="hljs-value"><span class="hljs-string">"下載厳禁"</span></span>,
@@ -2854,7 +2944,7 @@ https://web.zaico.co.jp/api/v1/shipping_clients?page=1</code></pre>
 ]</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span>
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 07 Oct 2023</p><script>/* eslint-env browser */
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 10 Oct 2023</p><script>/* eslint-env browser */
 /* eslint quotes: [2, "single"] */
 'use strict';
 


### PR DESCRIPTION
## 背景・課題
[こちらのPR](https://github.com/zaicodev/zaico_web/pull/1150)に伴うAPIドキュメント修正です。

## 対応概要

- 出庫API（一覧取得・個別取得・登録・更新）に発送情報を追記
- 発送元一覧取得を追記
- 一部インデントがズレてたのでついでに修正した
