### PR TITLE
[MIN-32] 写真・ファイル追加のパラメタ例の誤りを修正

### DIFF
--- a/includes/api/inventory_attachments.md
+++ b/includes/api/inventory_attachments.md
@@ -39,8 +39,7 @@
 
     + Attributes
        + inventory_attachment (object)  
-           + item_file: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA... (string, required) - 添付する写真またはファイル
-           + original_filename: `new_image.jpg` (string) - ファイル名
+           + item_file: `添付する写真またはファイルのバイナリデータ` (string, required) - 添付する写真またはファイルのバイナリデータ
 
 + Response 200 (application/json)
     + Attributes


### PR DESCRIPTION
## 背景・課題
base64を渡すようなサンプルになっていたが、正しくはバイナリデータを想定してるため修正しました。

## 対応概要
Aglioでバイナリデータを表現する方法が見つからなかったので、もう文字で書きました。
[改修後のスクショ](https://gyazo.com/2b02c68b462a5ad524d595bf9d1fa8be)
