### PR TITLE
DEV-8096 レスポンス内のprice, quantity関連の型をnumber -> stringに変更

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build Document
         run: yarn build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success()
         with:
           name: API Document

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,5 +1,11 @@
-<!DOCTYPE html><html><head><meta charset="utf-8"><title>zaico API Document</title><link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"><style>@import url('https://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200');.hljs-comment,.hljs-title{color:#8e908c}.hljs-variable,.hljs-attribute,.hljs-tag,.hljs-regexp,.ruby .hljs-constant,.xml .hljs-tag .hljs-title,.xml .hljs-pi,.xml .hljs-doctype,.html .hljs-doctype,.css .hljs-id,.css .hljs-class,.css .hljs-pseudo{color:#c82829}.hljs-number,.hljs-preprocessor,.hljs-pragma,.hljs-built_in,.hljs-literal,.hljs-params,.hljs-constant{color:#f5871f}.ruby .hljs-class .hljs-title,.css .hljs-rules .hljs-attribute{color:#eab700}.hljs-string,.hljs-value,.hljs-inheritance,.hljs-header,.ruby .hljs-symbol,.xml .hljs-cdata{color:#718c00}.css .hljs-hexcolor{color:#3e999f}.hljs-function,.python .hljs-decorator,.python .hljs-title,.ruby .hljs-function .hljs-title,.ruby .hljs-title .hljs-keyword,.perl .hljs-sub,.javascript .hljs-title,.coffeescript .hljs-title{color:#4271ae}.hljs-keyword,.javascript .hljs-function{color:#8959a8}.hljs{display:block;background:white;color:#4d4d4c;padding:.5em}.coffeescript .javascript,.javascript .xml,.tex .hljs-formula,.xml .javascript,.xml .vbscript,.xml .css,.xml .hljs-cdata{opacity:.5}.right .hljs-comment{color:#969896}.right .css .hljs-class,.right .css .hljs-id,.right .css .hljs-pseudo,.right .hljs-attribute,.right .hljs-regexp,.right .hljs-tag,.right .hljs-variable,.right .html .hljs-doctype,.right .ruby .hljs-constant,.right .xml .hljs-doctype,.right .xml .hljs-pi,.right .xml .hljs-tag .hljs-title{color:#c66}.right .hljs-built_in,.right .hljs-constant,.right .hljs-literal,.right .hljs-number,.right .hljs-params,.right .hljs-pragma,.right .hljs-preprocessor{color:#de935f}.right .css .hljs-rule .hljs-attribute,.right .ruby .hljs-class .hljs-title{color:#f0c674}.right .hljs-header,.right .hljs-inheritance,.right .hljs-name,.right .hljs-string,.right .hljs-value,.right .ruby .hljs-symbol,.right .xml .hljs-cdata{color:#b5bd68}.right .css .hljs-hexcolor,.right .hljs-title{color:#8abeb7}.right .coffeescript .hljs-title,.right .hljs-function,.right .javascript .hljs-title,.right .perl .hljs-sub,.right .python .hljs-decorator,.right .python .hljs-title,.right .ruby .hljs-function .hljs-title,.right .ruby .hljs-title .hljs-keyword{color:#81a2be}.right .hljs-keyword,.right .javascript .hljs-function{color:#b294bb}.right .hljs{display:block;overflow-x:auto;background:#1d1f21;color:#c5c8c6;padding:.5em;-webkit-text-size-adjust:none}.right .coffeescript .javascript,.right .javascript .xml,.right .tex .hljs-formula,.right .xml .css,.right .xml .hljs-cdata,.right .xml .javascript,.right .xml .vbscript{opacity:.5}body{color:black;background:white;font:400 14px / 1.42 'Roboto',Helvetica,sans-serif}header{border-bottom:1px solid #f2f2f2;margin-bottom:12px}h1,h2,h3,h4,h5{color:black;margin:12px 0}h1 .permalink,h2 .permalink,h3 .permalink,h4 .permalink,h5 .permalink{margin-left:0;opacity:0;transition:opacity .25s ease}h1:hover .permalink,h2:hover .permalink,h3:hover .permalink,h4:hover .permalink,h5:hover .permalink{opacity:1}.triple h1 .permalink,.triple h2 .permalink,.triple h3 .permalink,.triple h4 .permalink,.triple h5 .permalink{opacity:.15}.triple h1:hover .permalink,.triple h2:hover .permalink,.triple h3:hover .permalink,.triple h4:hover .permalink,.triple h5:hover .permalink{opacity:.15}h1{font:200 36px 'Raleway',Helvetica,sans-serif;font-size:36px}h2{font:200 36px 'Raleway',Helvetica,sans-serif;font-size:30px}h3{font-size:100%;text-transform:uppercase}h5{font-size:100%;font-weight:normal}p{margin:0 0 10px}p.choices{line-height:1.6}a{color:#428bca;text-decoration:none}li p{margin:0}hr.split{border:0;height:1px;width:100%;padding-left:6px;margin:12px auto;background-image:linear-gradient(to right, rgba(0,0,0,0) 20%, rgba(0,0,0,0.2) 51.4%, rgba(255,255,255,0.2) 51.4%, rgba(255,255,255,0) 80%)}dl dt{float:left;width:130px;clear:left;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:700}dl dd{margin-left:150px}blockquote{color:rgba(0,0,0,0.5);font-size:15.5px;padding:10px 20px;margin:12px 0;border-left:5px solid #e8e8e8}blockquote p:last-child{margin-bottom:0}pre{background-color:#f5f5f5;padding:12px;border:1px solid #cfcfcf;border-radius:6px;overflow:auto}pre code{color:black;background-color:transparent;padding:0;border:none}code{color:#444;background-color:#f5f5f5;font:'Inconsolata',monospace;padding:1px 4px;border:1px solid #cfcfcf;border-radius:3px}ul,ol{padding-left:2em}table{border-collapse:collapse;border-spacing:0;margin-bottom:12px}table tr:nth-child(2n){background-color:#fafafa}table th,table td{padding:6px 12px;border:1px solid #e6e6e6}.text-muted{opacity:.5}.note,.warning{padding:.3em 1em;margin:1em 0;border-radius:2px;font-size:90%}.note h1,.warning h1,.note h2,.warning h2,.note h3,.warning h3,.note h4,.warning h4,.note h5,.warning h5,.note h6,.warning h6{font-family:200 36px 'Raleway',Helvetica,sans-serif;font-size:135%;font-weight:500}.note p,.warning p{margin:.5em 0}.note{color:black;background-color:#f0f6fb;border-left:4px solid #428bca}.note h1,.note h2,.note h3,.note h4,.note h5,.note h6{color:#428bca}.warning{color:black;background-color:#fbf1f0;border-left:4px solid #c9302c}.warning h1,.warning h2,.warning h3,.warning h4,.warning h5,.warning h6{color:#c9302c}header{margin-top:24px}nav{position:fixed;top:24px;bottom:0;overflow-y:auto}nav .resource-group{padding:0}nav .resource-group .heading{position:relative}nav .resource-group .heading .chevron{position:absolute;top:12px;right:12px;opacity:.5}nav .resource-group .heading a{display:block;color:black;opacity:.7;border-left:2px solid transparent;margin:0}nav .resource-group .heading a:hover{text-decoration:none;background-color:bad-color;border-left:2px solid black}nav ul{list-style-type:none;padding-left:0}nav ul a{display:block;font-size:13px;color:rgba(0,0,0,0.7);padding:8px 12px;border-top:1px solid #d9d9d9;border-left:2px solid transparent;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}nav ul a:hover{text-decoration:none;background-color:bad-color;border-left:2px solid black}nav ul>li{margin:0}nav ul>li:first-child{margin-top:-12px}nav ul>li:last-child{margin-bottom:-12px}nav ul ul a{padding-left:24px}nav ul ul li{margin:0}nav ul ul li:first-child{margin-top:0}nav ul ul li:last-child{margin-bottom:0}nav>div>div>ul>li:first-child>a{border-top:none}.preload *{transition:none !important}.pull-left{float:left}.pull-right{float:right}.badge{display:inline-block;float:right;min-width:10px;min-height:14px;padding:3px 7px;font-size:12px;color:#000;background-color:#f2f2f2;border-radius:10px;margin:-2px 0}.badge.get{color:#70bbe1;background-color:#d9edf7}.badge.head{color:#70bbe1;background-color:#d9edf7}.badge.options{color:#70bbe1;background-color:#d9edf7}.badge.put{color:#f0db70;background-color:#fcf8e3}.badge.patch{color:#f0db70;background-color:#fcf8e3}.badge.post{color:#93cd7c;background-color:#dff0d8}.badge.delete{color:#ce8383;background-color:#f2dede}.collapse-button{float:right}.collapse-button .close{display:none;color:#428bca;cursor:pointer}.collapse-button .open{color:#428bca;cursor:pointer}.collapse-button.show .close{display:inline}.collapse-button.show .open{display:none}.collapse-content{max-height:0;overflow:hidden;transition:max-height .3s ease-in-out}nav{width:220px}.container{max-width:940px;margin-left:auto;margin-right:auto}.container .row .content{margin-left:244px;width:696px}.container .row:after{content:'';display:block;clear:both}.container-fluid nav{width:22%}.container-fluid .row .content{margin-left:24%}.container-fluid.triple nav{width:16.5%;padding-right:1px}.container-fluid.triple .row .content{position:relative;margin-left:16.5%;padding-left:24px}.middle:before,.middle:after{content:'';display:table}.middle:after{clear:both}.middle{box-sizing:border-box;width:51.5%;padding-right:12px}.right{box-sizing:border-box;float:right;width:48.5%;padding-left:12px}.right a{color:#428bca}.right h1,.right h2,.right h3,.right h4,.right h5,.right p,.right div{color:white}.right pre{background-color:#1d1f21;border:1px solid #1d1f21}.right pre code{color:#c5c8c6}.right .description{margin-top:12px}.triple .resource-heading{font-size:125%}.definition{margin-top:12px;margin-bottom:12px}.definition .method{font-weight:bold}.definition .method.get{color:#2e8ab8}.definition .method.head{color:#2e8ab8}.definition .method.options{color:#2e8ab8}.definition .method.post{color:#56b82e}.definition .method.put{color:#b8a22e}.definition .method.patch{color:#b8a22e}.definition .method.delete{color:#b82e2e}.definition .uri{word-break:break-all;word-wrap:break-word}.definition .hostname{opacity:.5}.example-names{background-color:#eee;padding:12px;border-radius:6px}.example-names .tab-button{cursor:pointer;color:black;border:1px solid #ddd;padding:6px;margin-left:12px}.example-names .tab-button.active{background-color:#d5d5d5}.right .example-names{background-color:#444}.right .example-names .tab-button{color:white;border:1px solid #666;border-radius:6px}.right .example-names .tab-button.active{background-color:#5e5e5e}#nav-background{position:fixed;left:0;top:0;bottom:0;width:16.5%;padding-right:14.4px;background-color:#fbfbfb;border-right:1px solid #f0f0f0;z-index:-1}#right-panel-background{position:absolute;right:-12px;top:-12px;bottom:-12px;width:48.6%;background-color:#333;z-index:-1}@media (max-width:1200px){nav{width:198px}.container{max-width:840px}.container .row .content{margin-left:224px;width:606px}}@media (max-width:992px){nav{width:169.4px}.container{max-width:720px}.container .row .content{margin-left:194px;width:526px}}@media (max-width:768px){nav{display:none}.container{width:95%;max-width:none}.container .row .content,.container-fluid .row .content,.container-fluid.triple .row .content{margin-left:auto;margin-right:auto;width:95%}#nav-background{display:none}#right-panel-background{width:48.6%}}.back-to-top{position:fixed;z-index:1;bottom:0;right:24px;padding:4px 8px;color:rgba(0,0,0,0.5);background-color:#f2f2f2;text-decoration:none !important;border-top:1px solid #d9d9d9;border-left:1px solid #d9d9d9;border-right:1px solid #d9d9d9;border-top-left-radius:3px;border-top-right-radius:3px}.resource-group{padding:12px;margin-bottom:12px;background-color:white;border:1px solid #d9d9d9;border-radius:6px}.resource-group h2.group-heading,.resource-group .heading a{padding:12px;margin:-12px -12px 12px -12px;background-color:#f2f2f2;border-bottom:1px solid #d9d9d9;border-top-left-radius:6px;border-top-right-radius:6px;white-space:nowrap;text-overflow:ellipsis;overflow:hidden}.triple .content .resource-group{padding:0;border:none}.triple .content .resource-group h2.group-heading,.triple .content .resource-group .heading a{margin:0 0 12px 0;border:1px solid #d9d9d9}nav .resource-group .heading a{padding:12px;margin-bottom:0}nav .resource-group .collapse-content{padding:0}.action{margin-bottom:12px;padding:12px 12px 0 12px;overflow:hidden;border:1px solid transparent;border-radius:6px}.action h4.action-heading{padding:6px 12px;margin:-12px -12px 12px -12px;border-bottom:1px solid transparent;border-top-left-radius:6px;border-top-right-radius:6px;overflow:hidden}.action h4.action-heading .name{float:right;font-weight:normal;padding:6px 0}.action h4.action-heading .method{padding:6px 12px;margin-right:12px;border-radius:3px;display:inline-block}.action h4.action-heading .method.get{color:#fff;background-color:#337ab7}.action h4.action-heading .method.head{color:#fff;background-color:#337ab7}.action h4.action-heading .method.options{color:#fff;background-color:#337ab7}.action h4.action-heading .method.put{color:#fff;background-color:#ed9c28}.action h4.action-heading .method.patch{color:#fff;background-color:#ed9c28}.action h4.action-heading .method.post{color:#fff;background-color:#5cb85c}.action h4.action-heading .method.delete{color:#fff;background-color:#d9534f}.action h4.action-heading code{color:#444;background-color:#f5f5f5;border-color:#cfcfcf;font-weight:normal;word-break:break-all;display:inline-block;margin-top:2px}.action dl.inner{padding-bottom:2px}.action .title{border-bottom:1px solid white;margin:0 -12px -1px -12px;padding:12px}.action.get{border-color:#bce8f1}.action.get h4.action-heading{color:#337ab7;background:#d9edf7;border-bottom-color:#bce8f1}.action.head{border-color:#bce8f1}.action.head h4.action-heading{color:#337ab7;background:#d9edf7;border-bottom-color:#bce8f1}.action.options{border-color:#bce8f1}.action.options h4.action-heading{color:#337ab7;background:#d9edf7;border-bottom-color:#bce8f1}.action.post{border-color:#d6e9c6}.action.post h4.action-heading{color:#5cb85c;background:#dff0d8;border-bottom-color:#d6e9c6}.action.put{border-color:#faebcc}.action.put h4.action-heading{color:#ed9c28;background:#fcf8e3;border-bottom-color:#faebcc}.action.patch{border-color:#faebcc}.action.patch h4.action-heading{color:#ed9c28;background:#fcf8e3;border-bottom-color:#faebcc}.action.delete{border-color:#ebccd1}.action.delete h4.action-heading{color:#d9534f;background:#f2dede;border-bottom-color:#ebccd1}</style></head><body class="preload"><a href="#top" class="text-muted back-to-top"><i class="fa fa-toggle-up"></i>&nbsp;Back to top</a><div class="container"><div class="row"><nav><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#認証">認証</a></div><div class="collapse-content"><ul><li><a href="#header-認証について">認証について</a></li><li><a href="#header-get">GET</a></li><li><a href="#header-概要">概要</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#在庫データ">在庫データ</a></div><div class="collapse-content"><ul><li><a href="#在庫データ-在庫データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>在庫データ一覧取得</a></li><li><a href="#在庫データ-在庫データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>在庫データ作成</a></li><li><a href="#在庫データ-在庫データ個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>在庫データ個別取得</a></li><li><a href="#在庫データ-在庫データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>在庫データ更新</a></li><li><a href="#在庫データ-在庫データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>在庫データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#出庫データ">出庫データ</a></div><div class="collapse-content"><ul><li><a href="#出庫データ-出庫データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>出庫データ一覧取得</a></li><li><a href="#出庫データ-出庫データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>出庫データ作成</a></li><li><a href="#出庫データ-出庫データ個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>出庫データ個別取得</a></li><li><a href="#出庫データ-出庫データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>出庫データ更新</a></li><li><a href="#出庫データ-出庫データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>出庫データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#出庫物品データ">出庫物品データ</a></div><div class="collapse-content"><ul><li><a href="#出庫物品データ-出庫物品データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>出庫物品データ一覧取得</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#入庫データ">入庫データ</a></div><div class="collapse-content"><ul><li><a href="#入庫データ-入庫データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>入庫データ一覧取得</a></li><li><a href="#入庫データ-入庫データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>入庫データ作成</a></li><li><a href="#入庫データ-入庫データ個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>入庫データ個別取得</a></li><li><a href="#入庫データ-入庫データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>入庫データ更新</a></li><li><a href="#入庫データ-入庫データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>入庫データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#入庫物品データ">入庫物品データ</a></div><div class="collapse-content"><ul><li><a href="#入庫物品データ-入庫物品データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>入庫物品データ一覧取得</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#取引先データ">取引先データ</a></div><div class="collapse-content"><ul><li><a href="#取引先データ-取引先データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>取引先データ一覧取得</a></li><li><a href="#取引先データ-取引先データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>取引先データ作成</a></li><li><a href="#取引先データ-取引先データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>取引先データ更新</a></li><li><a href="#取引先データ-取引先データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>取引先データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#発送元データ">発送元データ</a></div><div class="collapse-content"><ul><li><a href="#発送元データ-発送元データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>発送元データ一覧取得</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#在庫グループビューデータ">在庫グループビューデータ</a></div><div class="collapse-content"><ul><li><a href="#在庫グループビューデータ-一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>一覧取得</a></li><li><a href="#在庫グループビューデータ-個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>個別取得</a></li><li><a href="#在庫グループビューデータ-発注点の設定-put"><span class="badge put"><i class="fa fa-pencil"></i></span>発注点の設定</a></li><li><a href="#在庫グループビューデータ-発注点の警告on-post"><span class="badge post"><i class="fa fa-plus"></i></span>発注点の警告ON</a></li><li><a href="#在庫グループビューデータ-発注点の警告off-post"><span class="badge post"><i class="fa fa-plus"></i></span>発注点の警告OFF</a></li></ul></div></div><p style="text-align: center; word-wrap: break-word;"><a href="https://web.zaico.co.jp">https://web.zaico.co.jp</a></p></nav><div class="content"><header><h1 id="top">zaico API Document</h1></header><p>このドキュメントはZAICO APIの機能と使うために必要なパラメータなどを説明するものです。<br>
-2024年3月15日更新</p>
+<!DOCTYPE html><html><head><meta charset="utf-8"><title>zaico API Document</title><link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"><style>@import url('https://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200');.hljs-comment,.hljs-title{color:#8e908c}.hljs-variable,.hljs-attribute,.hljs-tag,.hljs-regexp,.ruby .hljs-constant,.xml .hljs-tag .hljs-title,.xml .hljs-pi,.xml .hljs-doctype,.html .hljs-doctype,.css .hljs-id,.css .hljs-class,.css .hljs-pseudo{color:#c82829}.hljs-number,.hljs-preprocessor,.hljs-pragma,.hljs-built_in,.hljs-literal,.hljs-params,.hljs-constant{color:#f5871f}.ruby .hljs-class .hljs-title,.css .hljs-rules .hljs-attribute{color:#eab700}.hljs-string,.hljs-value,.hljs-inheritance,.hljs-header,.ruby .hljs-symbol,.xml .hljs-cdata{color:#718c00}.css .hljs-hexcolor{color:#3e999f}.hljs-function,.python .hljs-decorator,.python .hljs-title,.ruby .hljs-function .hljs-title,.ruby .hljs-title .hljs-keyword,.perl .hljs-sub,.javascript .hljs-title,.coffeescript .hljs-title{color:#4271ae}.hljs-keyword,.javascript .hljs-function{color:#8959a8}.hljs{display:block;background:white;color:#4d4d4c;padding:.5em}.coffeescript .javascript,.javascript .xml,.tex .hljs-formula,.xml .javascript,.xml .vbscript,.xml .css,.xml .hljs-cdata{opacity:.5}.right .hljs-comment{color:#969896}.right .css .hljs-class,.right .css .hljs-id,.right .css .hljs-pseudo,.right .hljs-attribute,.right .hljs-regexp,.right .hljs-tag,.right .hljs-variable,.right .html .hljs-doctype,.right .ruby .hljs-constant,.right .xml .hljs-doctype,.right .xml .hljs-pi,.right .xml .hljs-tag .hljs-title{color:#c66}.right .hljs-built_in,.right .hljs-constant,.right .hljs-literal,.right .hljs-number,.right .hljs-params,.right .hljs-pragma,.right .hljs-preprocessor{color:#de935f}.right .css .hljs-rule .hljs-attribute,.right .ruby .hljs-class .hljs-title{color:#f0c674}.right .hljs-header,.right .hljs-inheritance,.right .hljs-name,.right .hljs-string,.right .hljs-value,.right .ruby .hljs-symbol,.right .xml .hljs-cdata{color:#b5bd68}.right .css .hljs-hexcolor,.right .hljs-title{color:#8abeb7}.right .coffeescript .hljs-title,.right .hljs-function,.right .javascript .hljs-title,.right .perl .hljs-sub,.right .python .hljs-decorator,.right .python .hljs-title,.right .ruby .hljs-function .hljs-title,.right .ruby .hljs-title .hljs-keyword{color:#81a2be}.right .hljs-keyword,.right .javascript .hljs-function{color:#b294bb}.right .hljs{display:block;overflow-x:auto;background:#1d1f21;color:#c5c8c6;padding:.5em;-webkit-text-size-adjust:none}.right .coffeescript .javascript,.right .javascript .xml,.right .tex .hljs-formula,.right .xml .css,.right .xml .hljs-cdata,.right .xml .javascript,.right .xml .vbscript{opacity:.5}body{color:black;background:white;font:400 14px / 1.42 'Roboto',Helvetica,sans-serif}header{border-bottom:1px solid #f2f2f2;margin-bottom:12px}h1,h2,h3,h4,h5{color:black;margin:12px 0}h1 .permalink,h2 .permalink,h3 .permalink,h4 .permalink,h5 .permalink{margin-left:0;opacity:0;transition:opacity .25s ease}h1:hover .permalink,h2:hover .permalink,h3:hover .permalink,h4:hover .permalink,h5:hover .permalink{opacity:1}.triple h1 .permalink,.triple h2 .permalink,.triple h3 .permalink,.triple h4 .permalink,.triple h5 .permalink{opacity:.15}.triple h1:hover .permalink,.triple h2:hover .permalink,.triple h3:hover .permalink,.triple h4:hover .permalink,.triple h5:hover .permalink{opacity:.15}h1{font:200 36px 'Raleway',Helvetica,sans-serif;font-size:36px}h2{font:200 36px 'Raleway',Helvetica,sans-serif;font-size:30px}h3{font-size:100%;text-transform:uppercase}h5{font-size:100%;font-weight:normal}p{margin:0 0 10px}p.choices{line-height:1.6}a{color:#428bca;text-decoration:none}li p{margin:0}hr.split{border:0;height:1px;width:100%;padding-left:6px;margin:12px auto;background-image:linear-gradient(to right, rgba(0,0,0,0) 20%, rgba(0,0,0,0.2) 51.4%, rgba(255,255,255,0.2) 51.4%, rgba(255,255,255,0) 80%)}dl dt{float:left;width:130px;clear:left;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:700}dl dd{margin-left:150px}blockquote{color:rgba(0,0,0,0.5);font-size:15.5px;padding:10px 20px;margin:12px 0;border-left:5px solid #e8e8e8}blockquote p:last-child{margin-bottom:0}pre{background-color:#f5f5f5;padding:12px;border:1px solid #cfcfcf;border-radius:6px;overflow:auto}pre code{color:black;background-color:transparent;padding:0;border:none}code{color:#444;background-color:#f5f5f5;font:'Inconsolata',monospace;padding:1px 4px;border:1px solid #cfcfcf;border-radius:3px}ul,ol{padding-left:2em}table{border-collapse:collapse;border-spacing:0;margin-bottom:12px}table tr:nth-child(2n){background-color:#fafafa}table th,table td{padding:6px 12px;border:1px solid #e6e6e6}.text-muted{opacity:.5}.note,.warning{padding:.3em 1em;margin:1em 0;border-radius:2px;font-size:90%}.note h1,.warning h1,.note h2,.warning h2,.note h3,.warning h3,.note h4,.warning h4,.note h5,.warning h5,.note h6,.warning h6{font-family:200 36px 'Raleway',Helvetica,sans-serif;font-size:135%;font-weight:500}.note p,.warning p{margin:.5em 0}.note{color:black;background-color:#f0f6fb;border-left:4px solid #428bca}.note h1,.note h2,.note h3,.note h4,.note h5,.note h6{color:#428bca}.warning{color:black;background-color:#fbf1f0;border-left:4px solid #c9302c}.warning h1,.warning h2,.warning h3,.warning h4,.warning h5,.warning h6{color:#c9302c}header{margin-top:24px}nav{position:fixed;top:24px;bottom:0;overflow-y:auto}nav .resource-group{padding:0}nav .resource-group .heading{position:relative}nav .resource-group .heading .chevron{position:absolute;top:12px;right:12px;opacity:.5}nav .resource-group .heading a{display:block;color:black;opacity:.7;border-left:2px solid transparent;margin:0}nav .resource-group .heading a:hover{text-decoration:none;background-color:bad-color;border-left:2px solid black}nav ul{list-style-type:none;padding-left:0}nav ul a{display:block;font-size:13px;color:rgba(0,0,0,0.7);padding:8px 12px;border-top:1px solid #d9d9d9;border-left:2px solid transparent;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}nav ul a:hover{text-decoration:none;background-color:bad-color;border-left:2px solid black}nav ul>li{margin:0}nav ul>li:first-child{margin-top:-12px}nav ul>li:last-child{margin-bottom:-12px}nav ul ul a{padding-left:24px}nav ul ul li{margin:0}nav ul ul li:first-child{margin-top:0}nav ul ul li:last-child{margin-bottom:0}nav>div>div>ul>li:first-child>a{border-top:none}.preload *{transition:none !important}.pull-left{float:left}.pull-right{float:right}.badge{display:inline-block;float:right;min-width:10px;min-height:14px;padding:3px 7px;font-size:12px;color:#000;background-color:#f2f2f2;border-radius:10px;margin:-2px 0}.badge.get{color:#70bbe1;background-color:#d9edf7}.badge.head{color:#70bbe1;background-color:#d9edf7}.badge.options{color:#70bbe1;background-color:#d9edf7}.badge.put{color:#f0db70;background-color:#fcf8e3}.badge.patch{color:#f0db70;background-color:#fcf8e3}.badge.post{color:#93cd7c;background-color:#dff0d8}.badge.delete{color:#ce8383;background-color:#f2dede}.collapse-button{float:right}.collapse-button .close{display:none;color:#428bca;cursor:pointer}.collapse-button .open{color:#428bca;cursor:pointer}.collapse-button.show .close{display:inline}.collapse-button.show .open{display:none}.collapse-content{max-height:0;overflow:hidden;transition:max-height .3s ease-in-out}nav{width:220px}.container{max-width:940px;margin-left:auto;margin-right:auto}.container .row .content{margin-left:244px;width:696px}.container .row:after{content:'';display:block;clear:both}.container-fluid nav{width:22%}.container-fluid .row .content{margin-left:24%}.container-fluid.triple nav{width:16.5%;padding-right:1px}.container-fluid.triple .row .content{position:relative;margin-left:16.5%;padding-left:24px}.middle:before,.middle:after{content:'';display:table}.middle:after{clear:both}.middle{box-sizing:border-box;width:51.5%;padding-right:12px}.right{box-sizing:border-box;float:right;width:48.5%;padding-left:12px}.right a{color:#428bca}.right h1,.right h2,.right h3,.right h4,.right h5,.right p,.right div{color:white}.right pre{background-color:#1d1f21;border:1px solid #1d1f21}.right pre code{color:#c5c8c6}.right .description{margin-top:12px}.triple .resource-heading{font-size:125%}.definition{margin-top:12px;margin-bottom:12px}.definition .method{font-weight:bold}.definition .method.get{color:#2e8ab8}.definition .method.head{color:#2e8ab8}.definition .method.options{color:#2e8ab8}.definition .method.post{color:#56b82e}.definition .method.put{color:#b8a22e}.definition .method.patch{color:#b8a22e}.definition .method.delete{color:#b82e2e}.definition .uri{word-break:break-all;word-wrap:break-word}.definition .hostname{opacity:.5}.example-names{background-color:#eee;padding:12px;border-radius:6px}.example-names .tab-button{cursor:pointer;color:black;border:1px solid #ddd;padding:6px;margin-left:12px}.example-names .tab-button.active{background-color:#d5d5d5}.right .example-names{background-color:#444}.right .example-names .tab-button{color:white;border:1px solid #666;border-radius:6px}.right .example-names .tab-button.active{background-color:#5e5e5e}#nav-background{position:fixed;left:0;top:0;bottom:0;width:16.5%;padding-right:14.4px;background-color:#fbfbfb;border-right:1px solid #f0f0f0;z-index:-1}#right-panel-background{position:absolute;right:-12px;top:-12px;bottom:-12px;width:48.6%;background-color:#333;z-index:-1}@media (max-width:1200px){nav{width:198px}.container{max-width:840px}.container .row .content{margin-left:224px;width:606px}}@media (max-width:992px){nav{width:169.4px}.container{max-width:720px}.container .row .content{margin-left:194px;width:526px}}@media (max-width:768px){nav{display:none}.container{width:95%;max-width:none}.container .row .content,.container-fluid .row .content,.container-fluid.triple .row .content{margin-left:auto;margin-right:auto;width:95%}#nav-background{display:none}#right-panel-background{width:48.6%}}.back-to-top{position:fixed;z-index:1;bottom:0;right:24px;padding:4px 8px;color:rgba(0,0,0,0.5);background-color:#f2f2f2;text-decoration:none !important;border-top:1px solid #d9d9d9;border-left:1px solid #d9d9d9;border-right:1px solid #d9d9d9;border-top-left-radius:3px;border-top-right-radius:3px}.resource-group{padding:12px;margin-bottom:12px;background-color:white;border:1px solid #d9d9d9;border-radius:6px}.resource-group h2.group-heading,.resource-group .heading a{padding:12px;margin:-12px -12px 12px -12px;background-color:#f2f2f2;border-bottom:1px solid #d9d9d9;border-top-left-radius:6px;border-top-right-radius:6px;white-space:nowrap;text-overflow:ellipsis;overflow:hidden}.triple .content .resource-group{padding:0;border:none}.triple .content .resource-group h2.group-heading,.triple .content .resource-group .heading a{margin:0 0 12px 0;border:1px solid #d9d9d9}nav .resource-group .heading a{padding:12px;margin-bottom:0}nav .resource-group .collapse-content{padding:0}.action{margin-bottom:12px;padding:12px 12px 0 12px;overflow:hidden;border:1px solid transparent;border-radius:6px}.action h4.action-heading{padding:6px 12px;margin:-12px -12px 12px -12px;border-bottom:1px solid transparent;border-top-left-radius:6px;border-top-right-radius:6px;overflow:hidden}.action h4.action-heading .name{float:right;font-weight:normal;padding:6px 0}.action h4.action-heading .method{padding:6px 12px;margin-right:12px;border-radius:3px;display:inline-block}.action h4.action-heading .method.get{color:#fff;background-color:#337ab7}.action h4.action-heading .method.head{color:#fff;background-color:#337ab7}.action h4.action-heading .method.options{color:#fff;background-color:#337ab7}.action h4.action-heading .method.put{color:#fff;background-color:#ed9c28}.action h4.action-heading .method.patch{color:#fff;background-color:#ed9c28}.action h4.action-heading .method.post{color:#fff;background-color:#5cb85c}.action h4.action-heading .method.delete{color:#fff;background-color:#d9534f}.action h4.action-heading code{color:#444;background-color:#f5f5f5;border-color:#cfcfcf;font-weight:normal;word-break:break-all;display:inline-block;margin-top:2px}.action dl.inner{padding-bottom:2px}.action .title{border-bottom:1px solid white;margin:0 -12px -1px -12px;padding:12px}.action.get{border-color:#bce8f1}.action.get h4.action-heading{color:#337ab7;background:#d9edf7;border-bottom-color:#bce8f1}.action.head{border-color:#bce8f1}.action.head h4.action-heading{color:#337ab7;background:#d9edf7;border-bottom-color:#bce8f1}.action.options{border-color:#bce8f1}.action.options h4.action-heading{color:#337ab7;background:#d9edf7;border-bottom-color:#bce8f1}.action.post{border-color:#d6e9c6}.action.post h4.action-heading{color:#5cb85c;background:#dff0d8;border-bottom-color:#d6e9c6}.action.put{border-color:#faebcc}.action.put h4.action-heading{color:#ed9c28;background:#fcf8e3;border-bottom-color:#faebcc}.action.patch{border-color:#faebcc}.action.patch h4.action-heading{color:#ed9c28;background:#fcf8e3;border-bottom-color:#faebcc}.action.delete{border-color:#ebccd1}.action.delete h4.action-heading{color:#d9534f;background:#f2dede;border-bottom-color:#ebccd1}</style></head><body class="preload"><a href="#top" class="text-muted back-to-top"><i class="fa fa-toggle-up"></i>&nbsp;Back to top</a><div class="container"><div class="row"><nav><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#認証">認証</a></div><div class="collapse-content"><ul><li><a href="#header-認証について">認証について</a></li><li><a href="#header-get">GET</a></li><li><a href="#header-概要">概要</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#在庫データ">在庫データ</a></div><div class="collapse-content"><ul><li><a href="#在庫データ-在庫データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>在庫データ一覧取得</a></li><li><a href="#在庫データ-在庫データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>在庫データ作成</a></li><li><a href="#在庫データ-在庫データ個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>在庫データ個別取得</a></li><li><a href="#在庫データ-在庫データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>在庫データ更新</a></li><li><a href="#在庫データ-在庫データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>在庫データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#在庫データの写真・ファイル">在庫データの写真・ファイル</a></div><div class="collapse-content"><ul><li><a href="#在庫データの写真・ファイル-写真・ファイル一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>写真・ファイル一覧取得</a></li><li><a href="#在庫データの写真・ファイル-写真・ファイル追加-post"><span class="badge post"><i class="fa fa-plus"></i></span>写真・ファイル追加</a></li><li><a href="#在庫データの写真・ファイル-写真・ファイル削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>写真・ファイル削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#セット品データ">セット品データ</a></div><div class="collapse-content"><ul><li><a href="#セット品データ-セット品データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>セット品データ一覧取得</a></li><li><a href="#セット品データ-セット品データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>セット品データ作成</a></li><li><a href="#セット品データ-セット品データ個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>セット品データ個別取得</a></li><li><a href="#セット品データ-セット品データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>セット品データ更新</a></li><li><a href="#セット品データ-セット品データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>セット品データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#出庫データ">出庫データ</a></div><div class="collapse-content"><ul><li><a href="#出庫データ-出庫データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>出庫データ一覧取得</a></li><li><a href="#出庫データ-出庫データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>出庫データ作成</a></li><li><a href="#出庫データ-出庫データ個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>出庫データ個別取得</a></li><li><a href="#出庫データ-出庫データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>出庫データ更新</a></li><li><a href="#出庫データ-出庫データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>出庫データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#出庫物品データ">出庫物品データ</a></div><div class="collapse-content"><ul><li><a href="#出庫物品データ-出庫物品データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>出庫物品データ一覧取得</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#入庫データ">入庫データ</a></div><div class="collapse-content"><ul><li><a href="#入庫データ-入庫データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>入庫データ一覧取得</a></li><li><a href="#入庫データ-入庫データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>入庫データ作成</a></li><li><a href="#入庫データ-入庫データ個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>入庫データ個別取得</a></li><li><a href="#入庫データ-入庫データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>入庫データ更新</a></li><li><a href="#入庫データ-入庫データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>入庫データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#入庫物品データ">入庫物品データ</a></div><div class="collapse-content"><ul><li><a href="#入庫物品データ-入庫物品データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>入庫物品データ一覧取得</a></li><li><a href="#入庫物品データ-入庫物品データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>入庫物品データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#取引先データ">取引先データ</a></div><div class="collapse-content"><ul><li><a href="#取引先データ-取引先データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>取引先データ一覧取得</a></li><li><a href="#取引先データ-取引先データ作成-post"><span class="badge post"><i class="fa fa-plus"></i></span>取引先データ作成</a></li><li><a href="#取引先データ-取引先データ更新-put"><span class="badge put"><i class="fa fa-pencil"></i></span>取引先データ更新</a></li><li><a href="#取引先データ-取引先データ削除-delete"><span class="badge delete"><i class="fa fa-times"></i></span>取引先データ削除</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#発送元データ">発送元データ</a></div><div class="collapse-content"><ul><li><a href="#発送元データ-発送元データ一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>発送元データ一覧取得</a></li></ul></div></div><div class="resource-group"><div class="heading"><div class="chevron"><i class="open fa fa-angle-down"></i></div><a href="#在庫グループビューデータ">在庫グループビューデータ</a></div><div class="collapse-content"><ul><li><a href="#在庫グループビューデータ-一覧取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>一覧取得</a></li><li><a href="#在庫グループビューデータ-個別取得-get"><span class="badge get"><i class="fa fa-arrow-down"></i></span>個別取得</a></li><li><a href="#在庫グループビューデータ-発注点の設定-put"><span class="badge put"><i class="fa fa-pencil"></i></span>発注点の設定</a></li><li><a href="#在庫グループビューデータ-発注点の警告on-post"><span class="badge post"><i class="fa fa-plus"></i></span>発注点の警告ON</a></li><li><a href="#在庫グループビューデータ-発注点の警告off-post"><span class="badge post"><i class="fa fa-plus"></i></span>発注点の警告OFF</a></li></ul></div></div><p style="text-align: center; word-wrap: break-word;"><a href="https://web.zaico.co.jp">https://web.zaico.co.jp</a></p></nav><div class="content"><header><h1 id="top">zaico API Document</h1></header><p>このドキュメントはZAICO APIの機能と使うために必要なパラメータなどを説明するものです。</p>
+<div style="border-color: #ebccd1; padding: 12px; margin-bottom: 12px; background: #f2dede;">
+<strong>バリエーションについて</strong>
+<p>2024年9月4日にリリースしたバリエーション機能については現在公開APIから操作することはできません。</p>
+<p>対応時期については決まり次第別途お知らせいたします。</p>
+<p>ご不便をおかけしますが、ご了承のほどよろしくお願いいたします。</p>
+</div>
+<p>2024年11月27日更新</p>
 <section id="認証" class="resource-group"><h2 class="group-heading">認証 <a href="#認証" class="permalink">&para;</a></h2><h2 id="header-認証について">認証について <a class="permalink" href="#header-認証について" aria-hidden="true">¶</a></h2>
 <h3 id="header-get">GET <a class="permalink" href="#header-get" aria-hidden="true">¶</a></h3>
 <h4 id="header-概要">概要 <a class="permalink" href="#header-概要" aria-hidden="true">¶</a></h4>
@@ -48,8 +54,8 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 <h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/inventories</span></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span><br><span class="hljs-attribute">Link</span>: <span class="hljs-string">&lt;https://web.zaico.co.jp/api/v1/inventories?page=1&gt;; rel="first", &lt;https://web.zaico.co.jp/api/v1/inventories?page=前のページ&gt;; rel="prev", &lt;https://web.zaico.co.jp/api/v1/inventories?page=次のページ&gt;; rel="next", &lt;https://web.zaico.co.jp/api/v1/inventories?page=最後のページ&gt;; rel="last"</span><br><span class="hljs-attribute">Total-Count</span>: <span class="hljs-string">在庫データ件数</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
   "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"在庫データ"</span></span>,
-  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
-  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
+  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
   "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"個"</span></span>,
   "<span class="hljs-attribute">category</span>": <span class="hljs-value"><span class="hljs-string">"製品"</span></span>,
   "<span class="hljs-attribute">state</span>": <span class="hljs-value"><span class="hljs-string">"新品"</span></span>,
@@ -64,19 +70,26 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">checked_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span>
   </span>}</span>,
   "<span class="hljs-attribute">optional_attributes</span>": <span class="hljs-value">[
-    {
-      "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"追加項目名"</span></span>,
-      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"追加項目値"</span>
-    </span>}
+    <span class="hljs-string">"name: `追加項目名`"</span>,
+    <span class="hljs-string">"value: `追加項目値`"</span>
   ]</span>,
   "<span class="hljs-attribute">quantity_management_attributes</span>": <span class="hljs-value">{
-    "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-number">5</span>
+    "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-string">"5"</span>
   </span>}</span>,
   "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span></span>,
   "<span class="hljs-attribute">updated_at `2018-03-27T09:38:19+09:00`</span>": <span class="hljs-value"><span class="hljs-string">""</span></span>,
   "<span class="hljs-attribute">create_user_name</span>": <span class="hljs-value"><span class="hljs-string">"田村 太郎"</span></span>,
   "<span class="hljs-attribute">update_user_name</span>": <span class="hljs-value"><span class="hljs-string">"田村 次郎"</span></span>,
-  "<span class="hljs-attribute">user_group</span>": <span class="hljs-value"><span class="hljs-string">"基本グループ"</span>
+  "<span class="hljs-attribute">user_group</span>": <span class="hljs-value"><span class="hljs-string">"基本グループ"</span></span>,
+  "<span class="hljs-attribute">is_quantity_auto_conversion_by_unit</span>": <span class="hljs-value"><span class="hljs-string">"1"</span></span>,
+  "<span class="hljs-attribute">quantity_auto_conversion_by_unit_name</span>": <span class="hljs-value"><span class="hljs-string">"箱"</span></span>,
+  "<span class="hljs-attribute">quantity_auto_conversion_by_unit_factor</span>": <span class="hljs-value"><span class="hljs-string">"12"</span></span>,
+  "<span class="hljs-attribute">attachments</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+    "<span class="hljs-attribute">original_filename</span>": <span class="hljs-value"><span class="hljs-string">"image.jpg"</span></span>,
+    "<span class="hljs-attribute">url</span>": <span class="hljs-value"><span class="hljs-string">"https://web.zaico.co.jp/files/image.jpg"</span></span>,
+    "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-01 09:00:00"</span>
+  </span>}
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
@@ -90,11 +103,11 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"在庫データタイトル"</span>
     </span>}</span>,
     "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"数量"</span>
     </span>}</span>,
     "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"予定フリー在庫数（フルプランのみ）"</span>
     </span>}</span>,
     "<span class="hljs-attribute">unit</span>": <span class="hljs-value">{
@@ -145,25 +158,20 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     </span>}</span>,
     "<span class="hljs-attribute">optional_attributes</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span></span>,
-      "<span class="hljs-attribute">items</span>": <span class="hljs-value">{
-        "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
-        "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
-          "<span class="hljs-attribute">name</span>": <span class="hljs-value">{
-            "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
-            "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"追加項目名"</span>
-          </span>}</span>,
-          "<span class="hljs-attribute">value</span>": <span class="hljs-value">{
-            "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
-            "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"追加項目値"</span>
-          </span>}
+      "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+        </span>},
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
         </span>}
-      </span>}
+      ]
     </span>}</span>,
     "<span class="hljs-attribute">quantity_management_attributes</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
       "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
         "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value">{
-          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
           "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発注点"</span>
         </span>}
       </span>}
@@ -187,6 +195,43 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">user_group</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ユーザーグループ"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">is_quantity_auto_conversion_by_unit</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位換算するかどうか。\"1\"なら単位換算する、\"0\"なら単位換算しない"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">quantity_auto_conversion_by_unit_name</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位換算後の単位名"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">quantity_auto_conversion_by_unit_factor</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位換算係数"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">attachments</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute"></span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+          "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{}
+        </span>}</span>,
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"写真・ファイルのID"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">original_filename</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ファイル名"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">url</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ファイルのURL"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">created_at</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"作成日時"</span>
+        </span>}
+      </span>}
     </span>}
   </span>}
 </span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="在庫データ-在庫データ作成" class="resource"><h3 class="resource-heading">在庫データ作成 <a href="#在庫データ-在庫データ作成" class="permalink">&nbsp;&para;</a></h3><div id="在庫データ-在庫データ作成-post" class="action post"><h4 class="action-heading"><div class="name"></div><a href="#在庫データ-在庫データ作成-post" class="method post">POST</a><code class="uri">/api/v1/inventories</code></h4><h4 id="header-処理概要-1">処理概要 <a class="permalink" href="#header-処理概要-1" aria-hidden="true">¶</a></h4>
@@ -220,7 +265,136 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 <p>発注点を設定することも可能です</p>
 </li>
 </ul>
-<h4>Example URI</h4><div class="definition"><span class="method post">POST</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/inventories</span></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+<h4>Example URI</h4><div class="definition"><span class="method post">POST</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/inventories</span></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"在庫データ"</span></span>,
+  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"個"</span></span>,
+  "<span class="hljs-attribute">category</span>": <span class="hljs-value"><span class="hljs-string">"製品"</span></span>,
+  "<span class="hljs-attribute">state</span>": <span class="hljs-value"><span class="hljs-string">"新品"</span></span>,
+  "<span class="hljs-attribute">place</span>": <span class="hljs-value"><span class="hljs-string">"ZAICO倉庫"</span></span>,
+  "<span class="hljs-attribute">etc</span>": <span class="hljs-value"><span class="hljs-string">"備考"</span></span>,
+  "<span class="hljs-attribute">group_tag</span>": <span class="hljs-value"><span class="hljs-string">"グループタグ"</span></span>,
+  "<span class="hljs-attribute">user_group</span>": <span class="hljs-value"><span class="hljs-string">"ユーザーグループ"</span></span>,
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-string">"tw201800000000"</span></span>,
+  "<span class="hljs-attribute">item_image</span>": <span class="hljs-value"><span class="hljs-string">"base64-encoded-image"</span></span>,
+  "<span class="hljs-attribute">stocktake_attributes</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">checked_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">optional_attributes</span>": <span class="hljs-value">[
+    <span class="hljs-string">"name: `追加項目名`"</span>,
+    <span class="hljs-string">"value: `追加項目値`"</span>
+  ]</span>,
+  "<span class="hljs-attribute">quantity_management_attributes</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-string">"5"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">inventory_history</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">memo</span>": <span class="hljs-value"><span class="hljs-string">"変更履歴メモ"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">is_quantity_auto_conversion_by_unit</span>": <span class="hljs-value"><span class="hljs-string">"1"</span></span>,
+  "<span class="hljs-attribute">quantity_auto_conversion_by_unit_name</span>": <span class="hljs-value"><span class="hljs-string">"箱"</span></span>,
+  "<span class="hljs-attribute">quantity_auto_conversion_by_unit_factor</span>": <span class="hljs-value"><span class="hljs-string">"12"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">title</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"在庫データタイトル"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"数量"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">unit</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">category</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"カテゴリ"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">state</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"状態"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">place</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"保管場所"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">etc</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"備考"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">group_tag</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"グループタグ（フルプランのみ）"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">user_group</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ユーザーグループ(カンマ区切りで複数指定可)"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"バーコードの値"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">item_image</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">stocktake_attributes</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">checked_at</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"棚卸日"</span>
+        </span>}
+      </span>}
+    </span>}</span>,
+    "<span class="hljs-attribute">optional_attributes</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span></span>,
+      "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+        </span>},
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+        </span>}
+      ]
+    </span>}</span>,
+    "<span class="hljs-attribute">quantity_management_attributes</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発注点"</span>
+        </span>}
+      </span>}
+    </span>}</span>,
+    "<span class="hljs-attribute">inventory_history</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">memo</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"変更履歴のメモ"</span>
+        </span>}
+      </span>}
+    </span>}</span>,
+    "<span class="hljs-attribute">is_quantity_auto_conversion_by_unit</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位換算するかどうか。\"1\"なら単位換算する、\"0\"なら単位換算しない"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">quantity_auto_conversion_by_unit_name</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位換算後の単位名"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">quantity_auto_conversion_by_unit_factor</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位換算係数"</span>
+    </span>}
+  </span>}</span>,
+  "<span class="hljs-attribute">required</span>": <span class="hljs-value">[
+    <span class="hljs-string">"title"</span>
+  ]
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">200</span></span>,
   "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"success"</span></span>,
   "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Data was successfully created."</span></span>,
@@ -308,8 +482,8 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 </dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
   "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"在庫データ"</span></span>,
-  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
-  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
+  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
   "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"個"</span></span>,
   "<span class="hljs-attribute">category</span>": <span class="hljs-value"><span class="hljs-string">"製品"</span></span>,
   "<span class="hljs-attribute">state</span>": <span class="hljs-value"><span class="hljs-string">"新品"</span></span>,
@@ -324,19 +498,26 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">checked_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span>
   </span>}</span>,
   "<span class="hljs-attribute">optional_attributes</span>": <span class="hljs-value">[
-    {
-      "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"追加項目名"</span></span>,
-      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"追加項目値"</span>
-    </span>}
+    <span class="hljs-string">"name: `追加項目名`"</span>,
+    <span class="hljs-string">"value: `追加項目値`"</span>
   ]</span>,
   "<span class="hljs-attribute">quantity_management_attributes</span>": <span class="hljs-value">{
-    "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-number">5</span>
+    "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-string">"5"</span>
   </span>}</span>,
   "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span></span>,
   "<span class="hljs-attribute">updated_at `2018-03-27T09:38:19+09:00`</span>": <span class="hljs-value"><span class="hljs-string">""</span></span>,
   "<span class="hljs-attribute">create_user_name</span>": <span class="hljs-value"><span class="hljs-string">"田村 太郎"</span></span>,
   "<span class="hljs-attribute">update_user_name</span>": <span class="hljs-value"><span class="hljs-string">"田村 次郎"</span></span>,
-  "<span class="hljs-attribute">user_group</span>": <span class="hljs-value"><span class="hljs-string">"基本グループ"</span>
+  "<span class="hljs-attribute">user_group</span>": <span class="hljs-value"><span class="hljs-string">"基本グループ"</span></span>,
+  "<span class="hljs-attribute">is_quantity_auto_conversion_by_unit</span>": <span class="hljs-value"><span class="hljs-string">"1"</span></span>,
+  "<span class="hljs-attribute">quantity_auto_conversion_by_unit_name</span>": <span class="hljs-value"><span class="hljs-string">"箱"</span></span>,
+  "<span class="hljs-attribute">quantity_auto_conversion_by_unit_factor</span>": <span class="hljs-value"><span class="hljs-string">"12"</span></span>,
+  "<span class="hljs-attribute">attachments</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+    "<span class="hljs-attribute">original_filename</span>": <span class="hljs-value"><span class="hljs-string">"image.jpg"</span></span>,
+    "<span class="hljs-attribute">url</span>": <span class="hljs-value"><span class="hljs-string">"https://web.zaico.co.jp/files/image.jpg"</span></span>,
+    "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-01 09:00:00"</span>
+  </span>}
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
@@ -350,11 +531,11 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"在庫データタイトル"</span>
     </span>}</span>,
     "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"数量"</span>
     </span>}</span>,
     "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"予定フリー在庫数（フルプランのみ）"</span>
     </span>}</span>,
     "<span class="hljs-attribute">unit</span>": <span class="hljs-value">{
@@ -405,25 +586,20 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     </span>}</span>,
     "<span class="hljs-attribute">optional_attributes</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span></span>,
-      "<span class="hljs-attribute">items</span>": <span class="hljs-value">{
-        "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
-        "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
-          "<span class="hljs-attribute">name</span>": <span class="hljs-value">{
-            "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
-            "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"追加項目名"</span>
-          </span>}</span>,
-          "<span class="hljs-attribute">value</span>": <span class="hljs-value">{
-            "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
-            "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"追加項目値"</span>
-          </span>}
+      "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+        </span>},
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
         </span>}
-      </span>}
+      ]
     </span>}</span>,
     "<span class="hljs-attribute">quantity_management_attributes</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
       "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
         "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value">{
-          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
           "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発注点"</span>
         </span>}
       </span>}
@@ -447,6 +623,43 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">user_group</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ユーザーグループ"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">is_quantity_auto_conversion_by_unit</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位換算するかどうか。\"1\"なら単位換算する、\"0\"なら単位換算しない"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">quantity_auto_conversion_by_unit_name</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位換算後の単位名"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">quantity_auto_conversion_by_unit_factor</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位換算係数"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">attachments</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute"></span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+          "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{}
+        </span>}</span>,
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"写真・ファイルのID"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">original_filename</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ファイル名"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">url</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ファイルのURL"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">created_at</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"作成日時"</span>
+        </span>}
+      </span>}
     </span>}
   </span>}
 </span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>404</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
@@ -500,9 +713,141 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 <li>
 <p>発注点を設定することも可能です</p>
 </li>
+<li>
+<p>ユーザーグループが未指定または空の場合は場合は更新しません</p>
+</li>
 </ul>
 <h4>Example URI</h4><div class="definition"><span class="method put">PUT</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/inventories/<span class="hljs-attribute" title="id">1</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>id</dt><dd><code>number</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>1</span></span><p>在庫データのID</p>
-</dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+</dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"在庫データ"</span></span>,
+  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"個"</span></span>,
+  "<span class="hljs-attribute">category</span>": <span class="hljs-value"><span class="hljs-string">"製品"</span></span>,
+  "<span class="hljs-attribute">state</span>": <span class="hljs-value"><span class="hljs-string">"新品"</span></span>,
+  "<span class="hljs-attribute">place</span>": <span class="hljs-value"><span class="hljs-string">"ZAICO倉庫"</span></span>,
+  "<span class="hljs-attribute">etc</span>": <span class="hljs-value"><span class="hljs-string">"備考"</span></span>,
+  "<span class="hljs-attribute">group_tag</span>": <span class="hljs-value"><span class="hljs-string">"グループタグ"</span></span>,
+  "<span class="hljs-attribute">user_group</span>": <span class="hljs-value"><span class="hljs-string">"ユーザーグループ"</span></span>,
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-string">"tw201800000000"</span></span>,
+  "<span class="hljs-attribute">item_image</span>": <span class="hljs-value"><span class="hljs-string">"base64-encoded-image"</span></span>,
+  "<span class="hljs-attribute">stocktake_attributes</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">checked_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">optional_attributes</span>": <span class="hljs-value">[
+    <span class="hljs-string">"name: `追加項目名`"</span>,
+    <span class="hljs-string">"value: `追加項目値`"</span>
+  ]</span>,
+  "<span class="hljs-attribute">quantity_management_attributes</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-string">"5"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">inventory_history</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">memo</span>": <span class="hljs-value"><span class="hljs-string">"変更履歴メモ"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">is_quantity_auto_conversion_by_unit</span>": <span class="hljs-value"><span class="hljs-string">"1"</span></span>,
+  "<span class="hljs-attribute">quantity_auto_conversion_by_unit_name</span>": <span class="hljs-value"><span class="hljs-string">"箱"</span></span>,
+  "<span class="hljs-attribute">quantity_auto_conversion_by_unit_factor</span>": <span class="hljs-value"><span class="hljs-string">"12"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">title</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"在庫データタイトル"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"数量"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">unit</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">category</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"カテゴリ"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">state</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"状態"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">place</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"保管場所"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">etc</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"備考"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">group_tag</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"グループタグ（フルプランのみ）"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">user_group</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ユーザーグループ(カンマ区切りで複数指定可)"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"バーコードの値"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">item_image</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">stocktake_attributes</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">checked_at</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"棚卸日"</span>
+        </span>}
+      </span>}
+    </span>}</span>,
+    "<span class="hljs-attribute">optional_attributes</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span></span>,
+      "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+        </span>},
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+        </span>}
+      ]
+    </span>}</span>,
+    "<span class="hljs-attribute">quantity_management_attributes</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発注点"</span>
+        </span>}
+      </span>}
+    </span>}</span>,
+    "<span class="hljs-attribute">inventory_history</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">memo</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"変更履歴のメモ"</span>
+        </span>}
+      </span>}
+    </span>}</span>,
+    "<span class="hljs-attribute">is_quantity_auto_conversion_by_unit</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位換算するかどうか。\"1\"なら単位換算する、\"0\"なら単位換算しない"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">quantity_auto_conversion_by_unit_name</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位換算後の単位名"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">quantity_auto_conversion_by_unit_factor</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位換算係数"</span>
+    </span>}
+  </span>}</span>,
+  "<span class="hljs-attribute">required</span>": <span class="hljs-value">[
+    <span class="hljs-string">"title"</span>
+  ]
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">200</span></span>,
   "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"success"</span></span>,
   "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Data was successfully updated."</span>
@@ -637,7 +982,722 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"エラー内容"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="出庫データ" class="resource-group"><h2 class="group-heading">出庫データ <a href="#出庫データ" class="permalink">&para;</a></h2><div id="出庫データ-出庫データ一覧取得" class="resource"><h3 class="resource-heading">出庫データ一覧取得 <a href="#出庫データ-出庫データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="出庫データ-出庫データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name">出庫データ一覧取得</div><a href="#出庫データ-出庫データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/packing_slips/</code></h4><h4 id="header-処理概要-5">処理概要 <a class="permalink" href="#header-処理概要-5" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="在庫データの写真・ファイル" class="resource-group"><h2 class="group-heading">在庫データの写真・ファイル <a href="#在庫データの写真・ファイル" class="permalink">&para;</a></h2><div id="在庫データの写真・ファイル-写真・ファイル一覧取得" class="resource"><h3 class="resource-heading">写真・ファイル一覧取得 <a href="#在庫データの写真・ファイル-写真・ファイル一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="在庫データの写真・ファイル-写真・ファイル一覧取得-get" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#在庫データの写真・ファイル-写真・ファイル一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/inventory_attachments/{inventory_id}</code></h4><h4 id="header-処理概要-5">処理概要 <a class="permalink" href="#header-処理概要-5" aria-hidden="true">¶</a></h4>
+<ul>
+<li>
+<p>指定した在庫データに紐づくすべての写真・ファイルを取得します。</p>
+</li>
+<li>
+<p>写真・ファイルが1件もない場合は、空の配列を返します。</p>
+</li>
+<li>
+<p>削除された写真・ファイルは含まれません。</p>
+</li>
+</ul>
+<h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/inventory_attachments/<span class="hljs-attribute" title="inventory_id">12345</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>inventory_id</dt><dd><code>string</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>12345</span></span><p>在庫データID</p>
+</dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>[
+  {
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+    "<span class="hljs-attribute">original_filename</span>": <span class="hljs-value"><span class="hljs-string">"image1.jpg"</span></span>,
+    "<span class="hljs-attribute">url</span>": <span class="hljs-value"><span class="hljs-string">"https://web.zaico.co.jp/files/image1.jpg"</span></span>,
+    "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-01 09:00:00"</span>
+  </span>}
+]</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="在庫データの写真・ファイル-写真・ファイル追加" class="resource"><h3 class="resource-heading">写真・ファイル追加 <a href="#在庫データの写真・ファイル-写真・ファイル追加" class="permalink">&nbsp;&para;</a></h3><div id="在庫データの写真・ファイル-写真・ファイル追加-post" class="action post"><h4 class="action-heading"><div class="name"></div><a href="#在庫データの写真・ファイル-写真・ファイル追加-post" class="method post">POST</a><code class="uri">/api/v1/inventory_attachments/{inventory_id}</code></h4><h4 id="header-処理概要-6">処理概要 <a class="permalink" href="#header-処理概要-6" aria-hidden="true">¶</a></h4>
+<ul>
+<li>
+<p>指定した在庫データに１つの新しい写真・ファイルを追加します。</p>
+</li>
+<li>
+<p>１つの在庫に添付できる写真・ファイルの数は合計10件までです。</p>
+</li>
+</ul>
+<h4>Example URI</h4><div class="definition"><span class="method post">POST</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/inventory_attachments/<span class="hljs-attribute" title="inventory_id">12345</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>inventory_id</dt><dd><code>string</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>12345</span></span><p>在庫データID</p>
+</dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">multipart/form-data</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">inventory_attachment</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">item_file</span>": <span class="hljs-value"><span class="hljs-string">"添付する写真またはファイルのバイナリデータ"</span>
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">inventory_attachment</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">item_file</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"添付する写真またはファイルのバイナリデータ"</span>
+        </span>}
+      </span>}</span>,
+      "<span class="hljs-attribute">required</span>": <span class="hljs-value">[
+        <span class="hljs-string">"item_file"</span>
+      ]
+    </span>}
+  </span>}</span>,
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span>
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
+  "<span class="hljs-attribute">original_filename: `new_image.jpg`</span>": <span class="hljs-value"><span class="hljs-string">"Hello, world!"</span></span>,
+  "<span class="hljs-attribute">url</span>": <span class="hljs-value"><span class="hljs-string">"https://web.zaico.co.jp/files/new_image.jpg"</span></span>,
+  "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-01 09:00:00"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"追加された写真・ファイルのID"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">original_filename: `new_image.jpg`</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ファイル名"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">url</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ファイルのURL"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">created_at</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"作成日時"</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="在庫データの写真・ファイル-写真・ファイル削除" class="resource"><h3 class="resource-heading">写真・ファイル削除 <a href="#在庫データの写真・ファイル-写真・ファイル削除" class="permalink">&nbsp;&para;</a></h3><div id="在庫データの写真・ファイル-写真・ファイル削除-delete" class="action delete"><h4 class="action-heading"><div class="name"></div><a href="#在庫データの写真・ファイル-写真・ファイル削除-delete" class="method delete">DELETE</a><code class="uri">/api/v1/inventory_attachments/{inventory_id}/{inventory_attachment_id}</code></h4><h4 id="header-処理概要-7">処理概要 <a class="permalink" href="#header-処理概要-7" aria-hidden="true">¶</a></h4>
+<ul>
+<li>指定した在庫データから写真・ファイルを削除します。</li>
+</ul>
+<h4>Example URI</h4><div class="definition"><span class="method delete">DELETE</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/inventory_attachments/<span class="hljs-attribute" title="inventory_id">12345</span>/<span class="hljs-attribute" title="inventory_attachment_id">6789</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>inventory_id</dt><dd><code>string</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>12345</span></span><p>在庫データID</p>
+</dd><dt>inventory_attachment_id</dt><dd><code>integer</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>6789</span></span><p>削除する写真・ファイルのID</p>
+</dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong></div></div></div></section><section id="セット品データ" class="resource-group"><h2 class="group-heading">セット品データ <a href="#セット品データ" class="permalink">&para;</a></h2><div id="セット品データ-セット品データ一覧取得" class="resource"><h3 class="resource-heading">セット品データ一覧取得 <a href="#セット品データ-セット品データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="セット品データ-セット品データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#セット品データ-セット品データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/inventories_sets</code></h4><h4 id="header-処理概要-8">処理概要 <a class="permalink" href="#header-処理概要-8" aria-hidden="true">¶</a></h4>
+<ul>
+<li>
+<p>自分のアカウントに登録されているセット品データのすべてを返します</p>
+</li>
+<li>
+<p>セット品データが1件も無い場合は、空の配列を返します</p>
+</li>
+<li>
+<p>セット品データが100件以上ある場合はページネーションで分割され、100件ごとセット品データを返します</p>
+</li>
+<li>
+<p>任意のページを取得するにはURLにクエリ「page=」をつけることで取得できます</p>
+</li>
+<li>
+<p>ページ情報はHTTPヘッダ&quot;Link&quot;に最初のページ、前のページ、次のページ、最後のページそれぞれ,(カンマ)で区切られ返されます。最初のページでは「前のページ」、最後のページでは「次のページ」項目は表示されません</p>
+</li>
+<li>
+<p>Link, Total-Countヘッダはセット品一覧でのみ返されます</p>
+</li>
+<li>
+<p>各セット品データの項目について以下のようになります</p>
+<ul>
+<li>id : セット品データID</li>
+<li>title : セット品名</li>
+<li>price : 価格</li>
+<li>code : コード</li>
+<li>memo : メモ</li>
+<li>update_user_id : 更新ユーザーID</li>
+<li>available_delivery_quantity : 出庫可能数量</li>
+<li>created_at : 作成日時</li>
+<li>updated_at : 更新日時</li>
+<li>inventories_set_items : セット品構成品目
+<ul>
+<li>inventory_id : 在庫ID</li>
+<li>quantity : 数量</li>
+<li>created_at : 作成日時</li>
+<li>updated_at : 更新日時</li>
+<li>inventory_title : 在庫名</li>
+<li>inventory_quantity : 在庫数量</li>
+<li>inventory_del_flg : 在庫削除フラグ</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/inventories_sets</span></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span><br><span class="hljs-attribute">Link</span>: <span class="hljs-string">&lt;https://web.zaico.co.jp/api/v1/inventories_sets?page=1&gt;; rel="first", &lt;https://web.zaico.co.jp/api/v1/inventories_sets?page=前のページ&gt;; rel="prev", &lt;https://web.zaico.co.jp/api/v1/inventories_sets?page=次のページ&gt;; rel="next", &lt;https://web.zaico.co.jp/api/v1/inventories_sets?page=最後のページ&gt;; rel="last"</span><br><span class="hljs-attribute">Total-Count</span>: <span class="hljs-string">セット品データ件数</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>[
+  {
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">123</span></span>,
+    "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"セット品A"</span></span>,
+    "<span class="hljs-attribute">price</span>": <span class="hljs-value"><span class="hljs-string">"1000"</span></span>,
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-string">"123456"</span></span>,
+    "<span class="hljs-attribute">memo</span>": <span class="hljs-value"><span class="hljs-string">"メモ"</span></span>,
+    "<span class="hljs-attribute">update_user_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+    "<span class="hljs-attribute">available_delivery_quantity</span>": <span class="hljs-value"><span class="hljs-string">"5"</span></span>,
+    "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-01 09:00:00"</span></span>,
+    "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-02 10:00:00"</span></span>,
+    "<span class="hljs-attribute">inventories_set_items</span>": <span class="hljs-value">[
+      {
+        "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+        "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"1"</span></span>,
+        "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-01 09:00:00"</span></span>,
+        "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-02 10:00:00"</span></span>,
+        "<span class="hljs-attribute">inventory_title</span>": <span class="hljs-value"><span class="hljs-string">"構成部品A"</span></span>,
+        "<span class="hljs-attribute">inventory_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+        "<span class="hljs-attribute">inventory_del_flg</span>": <span class="hljs-value"><span class="hljs-literal">false</span>
+      </span>},
+      {
+        "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">2</span></span>,
+        "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"2"</span></span>,
+        "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-01 09:00:00"</span></span>,
+        "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-02 10:00:00"</span></span>,
+        "<span class="hljs-attribute">inventory_title</span>": <span class="hljs-value"><span class="hljs-string">"構成部品B"</span></span>,
+        "<span class="hljs-attribute">inventory_quantity</span>": <span class="hljs-value"><span class="hljs-string">"20"</span></span>,
+        "<span class="hljs-attribute">inventory_del_flg</span>": <span class="hljs-value"><span class="hljs-literal">false</span>
+      </span>}
+    ]
+  </span>}
+]</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="セット品データ-セット品データ作成" class="resource"><h3 class="resource-heading">セット品データ作成 <a href="#セット品データ-セット品データ作成" class="permalink">&nbsp;&para;</a></h3><div id="セット品データ-セット品データ作成-post" class="action post"><h4 class="action-heading"><div class="name"></div><a href="#セット品データ-セット品データ作成-post" class="method post">POST</a><code class="uri">/api/v1/inventories_sets</code></h4><h4 id="header-処理概要-9">処理概要 <a class="permalink" href="#header-処理概要-9" aria-hidden="true">¶</a></h4>
+<ul>
+<li>
+<p>セット品データを作成します</p>
+</li>
+<li>
+<p>送られたパラメータにタイトルが無い場合やデータが無い場合はエラーを返します</p>
+</li>
+</ul>
+<h4>Example URI</h4><div class="definition"><span class="method post">POST</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/inventories_sets</span></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"セット品A"</span></span>,
+  "<span class="hljs-attribute">price</span>": <span class="hljs-value"><span class="hljs-number">1000</span></span>,
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-string">"123456"</span></span>,
+  "<span class="hljs-attribute">inventories_set_items_attributes</span>": <span class="hljs-value">[
+    {
+      "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+      "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">1</span>
+    </span>},
+    {
+      "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">2</span></span>,
+      "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">2</span>
+    </span>}
+  ]
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">title</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"セット品名"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">price</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"価格"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"コード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">inventories_set_items_attributes</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span></span>,
+      "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+          "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"在庫ID"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"数量"</span>
+            </span>}
+          </span>}</span>,
+          "<span class="hljs-attribute">required</span>": <span class="hljs-value">[
+            <span class="hljs-string">"inventory_id"</span>,
+            <span class="hljs-string">"quantity"</span>
+          ]
+        </span>},
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+          "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span>
+            </span>}
+          </span>}</span>,
+          "<span class="hljs-attribute">required</span>": <span class="hljs-value">[
+            <span class="hljs-string">"inventory_id"</span>,
+            <span class="hljs-string">"quantity"</span>
+          ]
+        </span>}
+      ]
+    </span>}
+  </span>}</span>,
+  "<span class="hljs-attribute">required</span>": <span class="hljs-value">[
+    <span class="hljs-string">"title"</span>
+  ]
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">200</span></span>,
+  "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"success"</span></span>,
+  "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Data was successfully created"</span></span>,
+  "<span class="hljs-attribute">data_id</span>": <span class="hljs-value"><span class="hljs-number">123</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ステータスコード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"状態"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">message</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">data_id</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"作成したセット品のID"</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>422</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">422</span></span>,
+  "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"error"</span></span>,
+  "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Invalid data"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ステータスコード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"状態"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">message</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="セット品データ-セット品データ個別取得" class="resource"><h3 class="resource-heading">セット品データ個別取得 <a href="#セット品データ-セット品データ個別取得" class="permalink">&nbsp;&para;</a></h3><div id="セット品データ-セット品データ個別取得-get" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#セット品データ-セット品データ個別取得-get" class="method get">GET</a><code class="uri">/api/v1/inventories_sets/{id}</code></h4><h4 id="header-処理概要-10">処理概要 <a class="permalink" href="#header-処理概要-10" aria-hidden="true">¶</a></h4>
+<ul>
+<li>
+<p>セット品データを1件のみ取得します</p>
+</li>
+<li>
+<p>パラメータに指定したIDのセット品が存在しない場合は404を返します</p>
+</li>
+<li>
+<p>各セット品データの項目について以下のようになります</p>
+<ul>
+<li>id : セット品データID</li>
+<li>title : セット品名</li>
+<li>price : 価格</li>
+<li>code : コード</li>
+<li>memo : メモ</li>
+<li>update_user_id : 更新ユーザーID</li>
+<li>available_delivery_quantity : 出庫可能数量</li>
+<li>available_delivery_logical_quantity : 予定フリー出庫可能数量 （フルプランでlogical_quantity機能を利用している場合のみ）</li>
+<li>created_at : 作成日時</li>
+<li>updated_at : 更新日時</li>
+<li>inventories_set_items : セット品構成品目
+<ul>
+<li>inventory_id : 在庫ID</li>
+<li>quantity : 数量</li>
+<li>created_at : 作成日時</li>
+<li>updated_at : 更新日時</li>
+<li>inventory_title : 在庫名</li>
+<li>inventory_quantity : 在庫数量</li>
+<li>inventory_logical_quantity: 予定フリー在庫数（フルプランでlogical_quantity機能を利用している場合のみ）</li>
+<li>inventory_del_flg : 在庫削除フラグ</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/inventories_sets/<span class="hljs-attribute" title="id">123</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>id</dt><dd><code>number</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>123</span></span><p>セット品ID</p>
+</dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">123</span></span>,
+  "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"セット品A"</span></span>,
+  "<span class="hljs-attribute">price</span>": <span class="hljs-value"><span class="hljs-string">"1000"</span></span>,
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-string">"123456"</span></span>,
+  "<span class="hljs-attribute">memo</span>": <span class="hljs-value"><span class="hljs-string">"メモ"</span></span>,
+  "<span class="hljs-attribute">update_user_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+  "<span class="hljs-attribute">available_delivery_quantity</span>": <span class="hljs-value"><span class="hljs-string">"5"</span></span>,
+  "<span class="hljs-attribute">available_delivery_logical_quantity</span>": <span class="hljs-value"><span class="hljs-string">"3"</span></span>,
+  "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-01 09:00:00"</span></span>,
+  "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-02 10:00:00"</span></span>,
+  "<span class="hljs-attribute">inventories_set_items</span>": <span class="hljs-value">[
+    {
+      "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+      "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"1"</span></span>,
+      "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-01 09:00:00"</span></span>,
+      "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-02 10:00:00"</span></span>,
+      "<span class="hljs-attribute">inventory_title</span>": <span class="hljs-value"><span class="hljs-string">"構成部品A"</span></span>,
+      "<span class="hljs-attribute">inventory_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+      "<span class="hljs-attribute">inventory_logical_quantity</span>": <span class="hljs-value"><span class="hljs-string">"8"</span></span>,
+      "<span class="hljs-attribute">inventory_del_flg</span>": <span class="hljs-value"><span class="hljs-literal">false</span>
+    </span>},
+    {
+      "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">2</span></span>,
+      "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"2"</span></span>,
+      "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-01 09:00:00"</span></span>,
+      "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-02 10:00:00"</span></span>,
+      "<span class="hljs-attribute">inventory_title</span>": <span class="hljs-value"><span class="hljs-string">"構成部品B"</span></span>,
+      "<span class="hljs-attribute">inventory_quantity</span>": <span class="hljs-value"><span class="hljs-string">"20"</span></span>,
+      "<span class="hljs-attribute">inventory_logical_quantity</span>": <span class="hljs-value"><span class="hljs-string">"18"</span></span>,
+      "<span class="hljs-attribute">inventory_del_flg</span>": <span class="hljs-value"><span class="hljs-literal">false</span>
+    </span>}
+  ]
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"セット品ID"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">title</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"セット品名"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">price</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"価格"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"コード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">memo</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メモ"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">update_user_id</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"更新ユーザーID"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">available_delivery_quantity</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"出庫可能数量"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">available_delivery_logical_quantity</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"予定フリー出庫可能数量"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">created_at</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"作成日時"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"更新日時"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">inventories_set_items</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span></span>,
+      "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+          "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"在庫ID"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"数量"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">created_at</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"作成日時"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"更新日時"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">inventory_title</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"在庫名"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">inventory_quantity</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"在庫数量"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">inventory_logical_quantity</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"予定フリー在庫数"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">inventory_del_flg</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"boolean"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"在庫削除フラグ"</span>
+            </span>}
+          </span>}
+        </span>},
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+          "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">created_at</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">inventory_title</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">inventory_quantity</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">inventory_logical_quantity</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">inventory_del_flg</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"boolean"</span>
+            </span>}
+          </span>}
+        </span>}
+      ]
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>404</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">404</span></span>,
+  "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"error"</span></span>,
+  "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Data not found"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ステータスコード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"状態"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">message</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="セット品データ-セット品データ更新" class="resource"><h3 class="resource-heading">セット品データ更新 <a href="#セット品データ-セット品データ更新" class="permalink">&nbsp;&para;</a></h3><div id="セット品データ-セット品データ更新-put" class="action put"><h4 class="action-heading"><div class="name"></div><a href="#セット品データ-セット品データ更新-put" class="method put">PUT</a><code class="uri">/api/v1/inventories_sets/{id}</code></h4><h4 id="header-処理概要-11">処理概要 <a class="permalink" href="#header-処理概要-11" aria-hidden="true">¶</a></h4>
+<ul>
+<li>
+<p>特定のセット品データを更新します</p>
+</li>
+<li>
+<p>パラメータに指定したIDのセット品が存在しない場合は404を返します</p>
+</li>
+</ul>
+<h4>Example URI</h4><div class="definition"><span class="method put">PUT</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/inventories_sets/<span class="hljs-attribute" title="id">123</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>id</dt><dd><code>number</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>123</span></span><p>セット品ID</p>
+</dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"セット品A"</span></span>,
+  "<span class="hljs-attribute">price</span>": <span class="hljs-value"><span class="hljs-number">1000</span></span>,
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-string">"123456"</span></span>,
+  "<span class="hljs-attribute">inventories_set_items_attributes</span>": <span class="hljs-value">[
+    {
+      "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+      "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">1</span>
+    </span>},
+    {
+      "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">2</span></span>,
+      "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">2</span>
+    </span>}
+  ]
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">title</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"セット品名"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">price</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"価格"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"コード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">inventories_set_items_attributes</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span></span>,
+      "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+          "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"在庫ID"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"数量"</span>
+            </span>}
+          </span>}</span>,
+          "<span class="hljs-attribute">required</span>": <span class="hljs-value">[
+            <span class="hljs-string">"inventory_id"</span>,
+            <span class="hljs-string">"quantity"</span>
+          ]
+        </span>},
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+          "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span>
+            </span>}</span>,
+            "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span>
+            </span>}
+          </span>}</span>,
+          "<span class="hljs-attribute">required</span>": <span class="hljs-value">[
+            <span class="hljs-string">"inventory_id"</span>,
+            <span class="hljs-string">"quantity"</span>
+          ]
+        </span>}
+      ]
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">200</span></span>,
+  "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"success"</span></span>,
+  "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Data was successfully updated"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ステータスコード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"状態"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">message</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>422</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">422</span></span>,
+  "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"error"</span></span>,
+  "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Invalid data"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ステータスコード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"状態"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">message</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>404</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">404</span></span>,
+  "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"error"</span></span>,
+  "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Data not found"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ステータスコード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"状態"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">message</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="セット品データ-セット品データ削除" class="resource"><h3 class="resource-heading">セット品データ削除 <a href="#セット品データ-セット品データ削除" class="permalink">&nbsp;&para;</a></h3><div id="セット品データ-セット品データ削除-delete" class="action delete"><h4 class="action-heading"><div class="name"></div><a href="#セット品データ-セット品データ削除-delete" class="method delete">DELETE</a><code class="uri">/api/v1/inventories_sets/{id}</code></h4><h4 id="header-処理概要-12">処理概要 <a class="permalink" href="#header-処理概要-12" aria-hidden="true">¶</a></h4>
+<ul>
+<li>
+<p>特定のセット品データを削除します</p>
+</li>
+<li>
+<p>パラメータに指定したIDのセット品が存在しない場合は404を返します</p>
+</li>
+</ul>
+<h4>Example URI</h4><div class="definition"><span class="method delete">DELETE</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/inventories_sets/<span class="hljs-attribute" title="id">123</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>id</dt><dd><code>number</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>123</span></span><p>セット品ID</p>
+</dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">200</span></span>,
+  "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"success"</span></span>,
+  "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Data was successfully deleted"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ステータスコード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"状態"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">message</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>422</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">422</span></span>,
+  "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"error"</span></span>,
+  "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Invalid data"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ステータスコード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"状態"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">message</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>404</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">404</span></span>,
+  "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"error"</span></span>,
+  "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Data not found"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ステータスコード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"状態"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">message</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="出庫データ" class="resource-group"><h2 class="group-heading">出庫データ <a href="#出庫データ" class="permalink">&para;</a></h2><div id="出庫データ-出庫データ一覧取得" class="resource"><h3 class="resource-heading">出庫データ一覧取得 <a href="#出庫データ-出庫データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="出庫データ-出庫データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name">出庫データ一覧取得</div><a href="#出庫データ-出庫データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/packing_slips/</code></h4><h4 id="header-処理概要-13">処理概要 <a class="permalink" href="#header-処理概要-13" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>自分のアカウントに登録されている出庫データのすべてを返します</p>
@@ -683,6 +1743,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 <li>updated_at : 出庫データ更新日</li>
 <li>deliveries : 出庫データに登録している在庫データ一覧
 <ul>
+<li>id : 出庫物品データID</li>
 <li>inventory_id : 在庫データID</li>
 <li>title : 物品名</li>
 <li>quantity : 出庫数量</li>
@@ -752,35 +1813,38 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span></span>,
     "<span class="hljs-attribute">deliveries</span>": <span class="hljs-value">[
       {
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
         "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
         "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"掃除機"</span></span>,
-        "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
+        "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"3"</span></span>,
         "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"台"</span></span>,
-        "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
+        "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-string">"100"</span></span>,
         "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"completed_delivery"</span></span>,
         "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
         "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-literal">null</span></span>,
         "<span class="hljs-attribute">etc</span>": <span class="hljs-value"><span class="hljs-string">"黒色"</span>
       </span>},
       {
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">2</span></span>,
         "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">2</span></span>,
         "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"テレビ"</span></span>,
-        "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
+        "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"3"</span></span>,
         "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"台"</span></span>,
-        "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
+        "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-string">"100"</span></span>,
         "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"completed_delivery"</span></span>,
         "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
         "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-literal">null</span></span>,
         "<span class="hljs-attribute">etc</span>": <span class="hljs-value"><span class="hljs-string">""</span>
       </span>},
       {
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
         "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
         "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"ビール"</span></span>,
-        "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">12</span></span>,
+        "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"12"</span></span>,
         "<span class="hljs-attribute">box_quantity</span>": <span class="hljs-value"><span class="hljs-string">"1"</span></span>,
         "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"瓶"</span></span>,
         "<span class="hljs-attribute">box_unit</span>": <span class="hljs-value"><span class="hljs-string">"箱"</span></span>,
-        "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
+        "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-string">"100"</span></span>,
         "<span class="hljs-attribute">unit_snapshot</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">piece_name</span>": <span class="hljs-value"><span class="hljs-string">"瓶"</span></span>,
           "<span class="hljs-attribute">box_name</span>": <span class="hljs-value"><span class="hljs-string">"箱"</span></span>,
@@ -829,9 +1893,9 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       {
         "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">5</span></span>,
         "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"掃除機"</span></span>,
-        "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
+        "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"3"</span></span>,
         "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"台"</span></span>,
-        "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
+        "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-string">"100"</span></span>,
         "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"completed_delivery"</span></span>,
         "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
         "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
@@ -842,7 +1906,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 ]</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span>
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="出庫データ-出庫データ作成" class="resource"><h3 class="resource-heading">出庫データ作成 <a href="#出庫データ-出庫データ作成" class="permalink">&nbsp;&para;</a></h3><div id="出庫データ-出庫データ作成-post" class="action post"><h4 class="action-heading"><div class="name">出庫データ作成</div><a href="#出庫データ-出庫データ作成-post" class="method post">POST</a><code class="uri">/api/v1/packing_slips/</code></h4><h4 id="header-処理概要-6">処理概要 <a class="permalink" href="#header-処理概要-6" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="出庫データ-出庫データ作成" class="resource"><h3 class="resource-heading">出庫データ作成 <a href="#出庫データ-出庫データ作成" class="permalink">&nbsp;&para;</a></h3><div id="出庫データ-出庫データ作成-post" class="action post"><h4 class="action-heading"><div class="name">出庫データ作成</div><a href="#出庫データ-出庫データ作成-post" class="method post">POST</a><code class="uri">/api/v1/packing_slips/</code></h4><h4 id="header-処理概要-14">処理概要 <a class="permalink" href="#header-処理概要-14" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>出庫データを作成します</p>
@@ -1089,7 +2153,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="出庫データ-出庫データ個別取得" class="resource"><h3 class="resource-heading">出庫データ個別取得 <a href="#出庫データ-出庫データ個別取得" class="permalink">&nbsp;&para;</a></h3><div id="出庫データ-出庫データ個別取得-get" class="action get"><h4 class="action-heading"><div class="name">出庫データ個別取得</div><a href="#出庫データ-出庫データ個別取得-get" class="method get">GET</a><code class="uri">/api/v1/packing_slips/{id}</code></h4><h4 id="header-処理概要-7">処理概要 <a class="permalink" href="#header-処理概要-7" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="出庫データ-出庫データ個別取得" class="resource"><h3 class="resource-heading">出庫データ個別取得 <a href="#出庫データ-出庫データ個別取得" class="permalink">&nbsp;&para;</a></h3><div id="出庫データ-出庫データ個別取得-get" class="action get"><h4 class="action-heading"><div class="name">出庫データ個別取得</div><a href="#出庫データ-出庫データ個別取得-get" class="method get">GET</a><code class="uri">/api/v1/packing_slips/{id}</code></h4><h4 id="header-処理概要-15">処理概要 <a class="permalink" href="#header-処理概要-15" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>出庫データを1件のみ取得します</p>
@@ -1191,9 +2255,9 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     {
       "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
       "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"掃除機"</span></span>,
-      "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
+      "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"3"</span></span>,
       "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"台"</span></span>,
-      "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
+      "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-string">"100"</span></span>,
       "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"completed_delivery"</span></span>,
       "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
       "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-literal">null</span></span>,
@@ -1202,9 +2266,9 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     {
       "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">2</span></span>,
       "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"テレビ"</span></span>,
-      "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
+      "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"3"</span></span>,
       "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"台"</span></span>,
-      "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
+      "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-string">"100"</span></span>,
       "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"completed_delivery"</span></span>,
       "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
       "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2019-09-01"</span></span>,
@@ -1282,7 +2346,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
               "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"物品名"</span>
             </span>}</span>,
             "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
-              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
               "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"出庫数量"</span>
             </span>}</span>,
             "<span class="hljs-attribute">unit</span>": <span class="hljs-value">{
@@ -1290,7 +2354,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
               "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位"</span>
             </span>}</span>,
             "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value">{
-              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
               "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"納品単価"</span>
             </span>}</span>,
             "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
@@ -1322,7 +2386,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
               "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"物品名"</span>
             </span>}</span>,
             "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
-              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
               "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"出庫数量"</span>
             </span>}</span>,
             "<span class="hljs-attribute">unit</span>": <span class="hljs-value">{
@@ -1330,7 +2394,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
               "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"単位"</span>
             </span>}</span>,
             "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value">{
-              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
               "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"納品単価"</span>
             </span>}</span>,
             "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
@@ -1437,7 +2501,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       </span>}
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="出庫データ-出庫データ更新" class="resource"><h3 class="resource-heading">出庫データ更新 <a href="#出庫データ-出庫データ更新" class="permalink">&nbsp;&para;</a></h3><div id="出庫データ-出庫データ更新-put" class="action put"><h4 class="action-heading"><div class="name">出庫データ更新</div><a href="#出庫データ-出庫データ更新-put" class="method put">PUT</a><code class="uri">/api/v1/packing_slips/{id}</code></h4><h4 id="header-処理概要-8">処理概要 <a class="permalink" href="#header-処理概要-8" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="出庫データ-出庫データ更新" class="resource"><h3 class="resource-heading">出庫データ更新 <a href="#出庫データ-出庫データ更新" class="permalink">&nbsp;&para;</a></h3><div id="出庫データ-出庫データ更新-put" class="action put"><h4 class="action-heading"><div class="name">出庫データ更新</div><a href="#出庫データ-出庫データ更新-put" class="method put">PUT</a><code class="uri">/api/v1/packing_slips/{id}</code></h4><h4 id="header-処理概要-16">処理概要 <a class="permalink" href="#header-処理概要-16" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>出庫データを更新します</p>
@@ -1671,7 +2735,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="出庫データ-出庫データ削除" class="resource"><h3 class="resource-heading">出庫データ削除 <a href="#出庫データ-出庫データ削除" class="permalink">&nbsp;&para;</a></h3><div id="出庫データ-出庫データ削除-delete" class="action delete"><h4 class="action-heading"><div class="name">出庫データ削除</div><a href="#出庫データ-出庫データ削除-delete" class="method delete">DELETE</a><code class="uri">/api/v1/packing_slips/{id}</code></h4><h4 id="header-処理概要-9">処理概要 <a class="permalink" href="#header-処理概要-9" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="出庫データ-出庫データ削除" class="resource"><h3 class="resource-heading">出庫データ削除 <a href="#出庫データ-出庫データ削除" class="permalink">&nbsp;&para;</a></h3><div id="出庫データ-出庫データ削除-delete" class="action delete"><h4 class="action-heading"><div class="name">出庫データ削除</div><a href="#出庫データ-出庫データ削除-delete" class="method delete">DELETE</a><code class="uri">/api/v1/packing_slips/{id}</code></h4><h4 id="header-処理概要-17">処理概要 <a class="permalink" href="#header-処理概要-17" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>特定の出庫データを削除します</p>
@@ -1727,7 +2791,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="出庫物品データ" class="resource-group"><h2 class="group-heading">出庫物品データ <a href="#出庫物品データ" class="permalink">&para;</a></h2><div id="出庫物品データ-出庫物品データ一覧取得" class="resource"><h3 class="resource-heading">出庫物品データ一覧取得 <a href="#出庫物品データ-出庫物品データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="出庫物品データ-出庫物品データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name">出庫物品データ一覧取得</div><a href="#出庫物品データ-出庫物品データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/deliveries</code></h4><h4 id="header-処理概要-10">処理概要 <a class="permalink" href="#header-処理概要-10" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="出庫物品データ" class="resource-group"><h2 class="group-heading">出庫物品データ <a href="#出庫物品データ" class="permalink">&para;</a></h2><div id="出庫物品データ-出庫物品データ一覧取得" class="resource"><h3 class="resource-heading">出庫物品データ一覧取得 <a href="#出庫物品データ-出庫物品データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="出庫物品データ-出庫物品データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name">出庫物品データ一覧取得</div><a href="#出庫物品データ-出庫物品データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/deliveries</code></h4><h4 id="header-処理概要-18">処理概要 <a class="permalink" href="#header-処理概要-18" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>自分のアカウントに登録されている出庫物品データを返します</p>
@@ -1783,9 +2847,9 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">packing_slip_id</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
     "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
     "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"掃除機"</span></span>,
-    "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
+    "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"3"</span></span>,
     "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"台"</span></span>,
-    "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
+    "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-string">"100"</span></span>,
     "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"completed_delivery"</span></span>,
     "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2021"</span></span>,
     "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"Hello, world!"</span></span>,
@@ -1798,9 +2862,9 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">packing_slip_id</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
     "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
     "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"掃除機"</span></span>,
-    "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
+    "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"3"</span></span>,
     "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"台"</span></span>,
-    "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
+    "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-string">"100"</span></span>,
     "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"completed_delivery"</span></span>,
     "<span class="hljs-attribute">delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"2021"</span></span>,
     "<span class="hljs-attribute">estimated_delivery_date</span>": <span class="hljs-value"><span class="hljs-string">"Hello, world!"</span></span>,
@@ -1813,7 +2877,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span>
 </span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="入庫データ" class="resource-group"><h2 class="group-heading">入庫データ <a href="#入庫データ" class="permalink">&para;</a></h2><p>HOST: <a href="https://web.zaico.co.jp/">https://web.zaico.co.jp/</a></p>
-<div id="入庫データ-入庫データ一覧取得" class="resource"><h3 class="resource-heading">入庫データ一覧取得 <a href="#入庫データ-入庫データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="入庫データ-入庫データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name">入庫データ一覧取得</div><a href="#入庫データ-入庫データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/purchases/</code></h4><h4 id="header-処理概要-11">処理概要 <a class="permalink" href="#header-処理概要-11" aria-hidden="true">¶</a></h4>
+<div id="入庫データ-入庫データ一覧取得" class="resource"><h3 class="resource-heading">入庫データ一覧取得 <a href="#入庫データ-入庫データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="入庫データ-入庫データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name">入庫データ一覧取得</div><a href="#入庫データ-入庫データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/purchases/</code></h4><h4 id="header-処理概要-19">処理概要 <a class="permalink" href="#header-処理概要-19" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>自分のアカウントに登録されている入庫データのすべてを返します</p>
@@ -1854,10 +2918,12 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 <li>estimated_purchase_date　: 入庫予定日</li>
 <li>create_user_name : 入庫データ作成者名</li>
 <li>memo : 入庫メモ</li>
+<li>etc : 発注書備考</li>
 <li>created_at : 入庫データ作成日</li>
 <li>updated_at : 入庫データ更新日</li>
 <li>purchase_items : 入庫データに登録している在庫データ一覧
 <ul>
+<li>id : 入庫物品データID</li>
 <li>inventory_id : 在庫データID</li>
 <li>title : 物品名</li>
 <li>quantity : 入庫数量</li>
@@ -1878,11 +2944,12 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 <li>以下の3つのいずれかが設定されています</li>
 <li>not_ordered : 発注前</li>
 <li>ordered : 発注済み</li>
-<li>purchased : 入庫済み</li>
+<li>purchased : 入庫済</li>
 </ul>
 </li>
 <li>purchase_date: 入庫日</li>
-<li>estimated_purchase_date　: 入庫予定日</li>
+<li>estimated_purchase_date : 入庫予定日</li>
+<li>etc : 入庫物品メモ</li>
 </ul>
 </li>
 </ul>
@@ -1902,7 +2969,8 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">updated_at</span>": <span class="hljs-value"><span class="hljs-string">"2019-12-27T09:38:19+09:00"</span></span>,
     "<span class="hljs-attribute">purchase_items</span>": <span class="hljs-value">[
       {
-        "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-string">"1"</span></span>,
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+        "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
         "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"掃除機"</span></span>,
         "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"3"</span></span>,
         "<span class="hljs-attribute">box_quantity</span>": <span class="hljs-value"><span class="hljs-string">"3"</span></span>,
@@ -1914,7 +2982,8 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
         "<span class="hljs-attribute">estimated_purchase_date</span>": <span class="hljs-value"><span class="hljs-string">"2020-01-01"</span>
       </span>},
       {
-        "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-string">"1"</span></span>,
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">2</span></span>,
+        "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
         "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"掃除機"</span></span>,
         "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"3"</span></span>,
         "<span class="hljs-attribute">box_quantity</span>": <span class="hljs-value"><span class="hljs-string">"3"</span></span>,
@@ -1926,7 +2995,8 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
         "<span class="hljs-attribute">estimated_purchase_date</span>": <span class="hljs-value"><span class="hljs-string">"2020-01-01"</span>
       </span>},
       {
-        "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-string">"2"</span></span>,
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
+        "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">2</span></span>,
         "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"ビール"</span></span>,
         "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"12"</span></span>,
         "<span class="hljs-attribute">box_quantity</span>": <span class="hljs-value"><span class="hljs-string">"1"</span></span>,
@@ -1971,7 +3041,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 ]</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span>
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="入庫データ-入庫データ作成" class="resource"><h3 class="resource-heading">入庫データ作成 <a href="#入庫データ-入庫データ作成" class="permalink">&nbsp;&para;</a></h3><div id="入庫データ-入庫データ作成-post" class="action post"><h4 class="action-heading"><div class="name">入庫データ作成</div><a href="#入庫データ-入庫データ作成-post" class="method post">POST</a><code class="uri">/api/v1/purchases/</code></h4><h4 id="header-処理概要-12">処理概要 <a class="permalink" href="#header-処理概要-12" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="入庫データ-入庫データ作成" class="resource"><h3 class="resource-heading">入庫データ作成 <a href="#入庫データ-入庫データ作成" class="permalink">&nbsp;&para;</a></h3><div id="入庫データ-入庫データ作成-post" class="action post"><h4 class="action-heading"><div class="name">入庫データ作成</div><a href="#入庫データ-入庫データ作成-post" class="method post">POST</a><code class="uri">/api/v1/purchases/</code></h4><h4 id="header-処理概要-20">処理概要 <a class="permalink" href="#header-処理概要-20" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>入庫データを作成します</p>
@@ -2115,7 +3185,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="入庫データ-入庫データ個別取得" class="resource"><h3 class="resource-heading">入庫データ個別取得 <a href="#入庫データ-入庫データ個別取得" class="permalink">&nbsp;&para;</a></h3><div id="入庫データ-入庫データ個別取得-get" class="action get"><h4 class="action-heading"><div class="name">入庫データ個別取得</div><a href="#入庫データ-入庫データ個別取得-get" class="method get">GET</a><code class="uri">/api/v1/purchases/{id}</code></h4><h4 id="header-処理概要-13">処理概要 <a class="permalink" href="#header-処理概要-13" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="入庫データ-入庫データ個別取得" class="resource"><h3 class="resource-heading">入庫データ個別取得 <a href="#入庫データ-入庫データ個別取得" class="permalink">&nbsp;&para;</a></h3><div id="入庫データ-入庫データ個別取得-get" class="action get"><h4 class="action-heading"><div class="name">入庫データ個別取得</div><a href="#入庫データ-入庫データ個別取得-get" class="method get">GET</a><code class="uri">/api/v1/purchases/{id}</code></h4><h4 id="header-処理概要-21">処理概要 <a class="permalink" href="#header-処理概要-21" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>入庫データを1件のみ取得します</p>
@@ -2274,7 +3344,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="入庫データ-入庫データ更新" class="resource"><h3 class="resource-heading">入庫データ更新 <a href="#入庫データ-入庫データ更新" class="permalink">&nbsp;&para;</a></h3><div id="入庫データ-入庫データ更新-put" class="action put"><h4 class="action-heading"><div class="name">入庫データ更新</div><a href="#入庫データ-入庫データ更新-put" class="method put">PUT</a><code class="uri">/api/v1/purchases/{id}</code></h4><h4 id="header-処理概要-14">処理概要 <a class="permalink" href="#header-処理概要-14" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="入庫データ-入庫データ更新" class="resource"><h3 class="resource-heading">入庫データ更新 <a href="#入庫データ-入庫データ更新" class="permalink">&nbsp;&para;</a></h3><div id="入庫データ-入庫データ更新-put" class="action put"><h4 class="action-heading"><div class="name">入庫データ更新</div><a href="#入庫データ-入庫データ更新-put" class="method put">PUT</a><code class="uri">/api/v1/purchases/{id}</code></h4><h4 id="header-処理概要-22">処理概要 <a class="permalink" href="#header-処理概要-22" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>入庫データを更新します</p>
@@ -2411,7 +3481,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="入庫データ-入庫データ削除" class="resource"><h3 class="resource-heading">入庫データ削除 <a href="#入庫データ-入庫データ削除" class="permalink">&nbsp;&para;</a></h3><div id="入庫データ-入庫データ削除-delete" class="action delete"><h4 class="action-heading"><div class="name">入庫データ削除</div><a href="#入庫データ-入庫データ削除-delete" class="method delete">DELETE</a><code class="uri">/api/v1/purchases/{id}</code></h4><h4 id="header-処理概要-15">処理概要 <a class="permalink" href="#header-処理概要-15" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="入庫データ-入庫データ削除" class="resource"><h3 class="resource-heading">入庫データ削除 <a href="#入庫データ-入庫データ削除" class="permalink">&nbsp;&para;</a></h3><div id="入庫データ-入庫データ削除-delete" class="action delete"><h4 class="action-heading"><div class="name">入庫データ削除</div><a href="#入庫データ-入庫データ削除-delete" class="method delete">DELETE</a><code class="uri">/api/v1/purchases/{id}</code></h4><h4 id="header-処理概要-23">処理概要 <a class="permalink" href="#header-処理概要-23" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>特定の入庫データを削除します</p>
@@ -2467,7 +3537,7 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="入庫物品データ" class="resource-group"><h2 class="group-heading">入庫物品データ <a href="#入庫物品データ" class="permalink">&para;</a></h2><div id="入庫物品データ-入庫物品データ一覧取得" class="resource"><h3 class="resource-heading">入庫物品データ一覧取得 <a href="#入庫物品データ-入庫物品データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="入庫物品データ-入庫物品データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name">入庫物品データ一覧取得</div><a href="#入庫物品データ-入庫物品データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/purchases/items</code></h4><h4 id="header-処理概要-16">処理概要 <a class="permalink" href="#header-処理概要-16" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="入庫物品データ" class="resource-group"><h2 class="group-heading">入庫物品データ <a href="#入庫物品データ" class="permalink">&para;</a></h2><div id="入庫物品データ-入庫物品データ一覧取得" class="resource"><h3 class="resource-heading">入庫物品データ一覧取得 <a href="#入庫物品データ-入庫物品データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="入庫物品データ-入庫物品データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name">入庫物品データ一覧取得</div><a href="#入庫物品データ-入庫物品データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/purchases/items</code></h4><h4 id="header-処理概要-24">処理概要 <a class="permalink" href="#header-処理概要-24" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>自分のアカウントに登録されている入庫物品データを返します</p>
@@ -2522,9 +3592,9 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">purchase_id</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
     "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
     "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"掃除機"</span></span>,
-    "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">3</span></span>,
+    "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"3"</span></span>,
     "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"台"</span></span>,
-    "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">100</span></span>,
+    "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-string">"100"</span></span>,
     "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"purchased"</span></span>,
     "<span class="hljs-attribute">purchase_date</span>": <span class="hljs-value"><span class="hljs-string">"2021"</span></span>,
     "<span class="hljs-attribute">estimated_purchase_date</span>": <span class="hljs-value"><span class="hljs-string">"Hello, world!"</span></span>,
@@ -2536,9 +3606,9 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">purchase_id</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
     "<span class="hljs-attribute">inventory_id</span>": <span class="hljs-value"><span class="hljs-number">2</span></span>,
     "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"りんご"</span></span>,
-    "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
+    "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
     "<span class="hljs-attribute">unit</span>": <span class="hljs-value"><span class="hljs-string">"個"</span></span>,
-    "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-number">200</span></span>,
+    "<span class="hljs-attribute">unit_price</span>": <span class="hljs-value"><span class="hljs-string">"200"</span></span>,
     "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"purchased"</span></span>,
     "<span class="hljs-attribute">purchase_date</span>": <span class="hljs-value"><span class="hljs-string">"2021"</span></span>,
     "<span class="hljs-attribute">estimated_purchase_date</span>": <span class="hljs-value"><span class="hljs-string">"Hello, world!"</span></span>,
@@ -2549,7 +3619,63 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
 ]</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span>
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="取引先データ" class="resource-group"><h2 class="group-heading">取引先データ <a href="#取引先データ" class="permalink">&para;</a></h2><div id="取引先データ-取引先データ一覧取得" class="resource"><h3 class="resource-heading">取引先データ一覧取得 <a href="#取引先データ-取引先データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="取引先データ-取引先データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#取引先データ-取引先データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/customers/</code></h4><h4 id="header-処理概要-17">処理概要 <a class="permalink" href="#header-処理概要-17" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="入庫物品データ-入庫物品データ削除" class="resource"><h3 class="resource-heading">入庫物品データ削除 <a href="#入庫物品データ-入庫物品データ削除" class="permalink">&nbsp;&para;</a></h3><div id="入庫物品データ-入庫物品データ削除-delete" class="action delete"><h4 class="action-heading"><div class="name">入庫物品データ削除</div><a href="#入庫物品データ-入庫物品データ削除-delete" class="method delete">DELETE</a><code class="uri">/api/v1/purchases/items/{id}</code></h4><h4 id="header-処理概要-25">処理概要 <a class="permalink" href="#header-処理概要-25" aria-hidden="true">¶</a></h4>
+<ul>
+<li>
+<p>特定の入庫物品データを削除します</p>
+</li>
+<li>
+<p>入庫物品データの状態によって在庫データの取り扱いが変わります</p>
+<ul>
+<li>入庫前：変化なし</li>
+<li>入庫済：在庫データの数量を入庫数量分だけ戻します</li>
+</ul>
+</li>
+</ul>
+<h4>Example URI</h4><div class="definition"><span class="method delete">DELETE</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/purchases/items/<span class="hljs-attribute" title="id">1</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>id</dt><dd><code>number</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>1</span></span><p>入庫物品データのID</p>
+</dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">200</span></span>,
+  "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"success"</span></span>,
+  "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Data was successfully deleted"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ステータスコード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"状態"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">message</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>404</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">404</span></span>,
+  "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"error"</span></span>,
+  "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Purchase item not found"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">code</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"ステータスコード"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">status</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"状態"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">message</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="取引先データ" class="resource-group"><h2 class="group-heading">取引先データ <a href="#取引先データ" class="permalink">&para;</a></h2><div id="取引先データ-取引先データ一覧取得" class="resource"><h3 class="resource-heading">取引先データ一覧取得 <a href="#取引先データ-取引先データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="取引先データ-取引先データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#取引先データ-取引先データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/customers/</code></h4><h4 id="header-処理概要-26">処理概要 <a class="permalink" href="#header-処理概要-26" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>自分のアカウントに登録されている取引先データのすべてを返します</p>
@@ -2581,7 +3707,11 @@ https://web.zaico.co.jp/api/v1/customers?page=1</code></pre>
   "<span class="hljs-attribute">address</span>": <span class="hljs-value"><span class="hljs-string">"東京都港区"</span></span>,
   "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"港ビル"</span></span>,
   "<span class="hljs-attribute">phone_number</span>": <span class="hljs-value"><span class="hljs-string">"08012345678"</span></span>,
-  "<span class="hljs-attribute">etc</span>": <span class="hljs-value"><span class="hljs-string">"取引先"</span>
+  "<span class="hljs-attribute">etc</span>": <span class="hljs-value"><span class="hljs-string">"取引先"</span></span>,
+  "<span class="hljs-attribute">fax_number</span>": <span class="hljs-value"><span class="hljs-string">"5678"</span></span>,
+  "<span class="hljs-attribute">category</span>": <span class="hljs-value"><span class="hljs-string">"東京"</span></span>,
+  "<span class="hljs-attribute">customer_type</span>": <span class="hljs-value"><span class="hljs-string">"packing_slip"</span></span>,
+  "<span class="hljs-attribute">num</span>": <span class="hljs-value"><span class="hljs-string">"1"</span>
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
@@ -2621,9 +3751,25 @@ https://web.zaico.co.jp/api/v1/customers?page=1</code></pre>
     "<span class="hljs-attribute">etc</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"備考"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">fax_number</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"FAX番号"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">category</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"カテゴリ"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">customer_type</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"入出庫区分"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">num</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"取引先No."</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="取引先データ-取引先データ作成" class="resource"><h3 class="resource-heading">取引先データ作成 <a href="#取引先データ-取引先データ作成" class="permalink">&nbsp;&para;</a></h3><div id="取引先データ-取引先データ作成-post" class="action post"><h4 class="action-heading"><div class="name"></div><a href="#取引先データ-取引先データ作成-post" class="method post">POST</a><code class="uri">/api/v1/customers/</code></h4><h4 id="header-処理概要-18">処理概要 <a class="permalink" href="#header-処理概要-18" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="取引先データ-取引先データ作成" class="resource"><h3 class="resource-heading">取引先データ作成 <a href="#取引先データ-取引先データ作成" class="permalink">&nbsp;&para;</a></h3><div id="取引先データ-取引先データ作成-post" class="action post"><h4 class="action-heading"><div class="name"></div><a href="#取引先データ-取引先データ作成-post" class="method post">POST</a><code class="uri">/api/v1/customers/</code></h4><h4 id="header-処理概要-27">処理概要 <a class="permalink" href="#header-処理概要-27" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>取引先データを作成します</p>
@@ -2635,11 +3781,80 @@ https://web.zaico.co.jp/api/v1/customers?page=1</code></pre>
 <p>敬称は 様 または 御中が指定可能です</p>
 </li>
 <li>
+<p>入出庫区分は「packing_slip」または「purchase」が指定可能です</p>
+</li>
+<li>
 <p>パースできないJSONを送るとエラーを返します</p>
 </li>
 </ul>
 <h4>Example URI</h4><div class="definition"><span class="method post">POST</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/customers/</span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>id</dt><dd><code>number</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>1</span></span><p>取引先データのID</p>
-</dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+</dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"取引先A"</span></span>,
+  "<span class="hljs-attribute">email</span>": <span class="hljs-value"><span class="hljs-string">"zaico@example.com"</span></span>,
+  "<span class="hljs-attribute">name_postfix</span>": <span class="hljs-value"><span class="hljs-string">"様"</span></span>,
+  "<span class="hljs-attribute">zip</span>": <span class="hljs-value"><span class="hljs-string">"1234567"</span></span>,
+  "<span class="hljs-attribute">address</span>": <span class="hljs-value"><span class="hljs-string">"東京都港区"</span></span>,
+  "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"港ビル"</span></span>,
+  "<span class="hljs-attribute">phone_number</span>": <span class="hljs-value"><span class="hljs-string">"08012345678"</span></span>,
+  "<span class="hljs-attribute">etc</span>": <span class="hljs-value"><span class="hljs-string">"取引先"</span></span>,
+  "<span class="hljs-attribute">fax_number</span>": <span class="hljs-value"><span class="hljs-string">"5678"</span></span>,
+  "<span class="hljs-attribute">category</span>": <span class="hljs-value"><span class="hljs-string">"東京"</span></span>,
+  "<span class="hljs-attribute">customer_type</span>": <span class="hljs-value"><span class="hljs-string">"purchase"</span></span>,
+  "<span class="hljs-attribute">num</span>": <span class="hljs-value"><span class="hljs-string">"1"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">name</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"取引先名"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">email</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メールアドレス"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">name_postfix</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"敬称"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">zip</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"郵便番号"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">address</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"住所"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">building_name</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"建物名・部屋番号"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">phone_number</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"電話番号"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">etc</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"備考"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">fax_number</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"FAX番号"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">category</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"カテゴリ"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">customer_type</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"入出庫区分"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">num</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"取引先No."</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">200</span></span>,
   "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"success"</span></span>,
   "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Data was successfully created"</span></span>,
@@ -2707,7 +3922,7 @@ https://web.zaico.co.jp/api/v1/customers?page=1</code></pre>
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"エラー内容"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="取引先データ-取引先データ更新" class="resource"><h3 class="resource-heading">取引先データ更新 <a href="#取引先データ-取引先データ更新" class="permalink">&nbsp;&para;</a></h3><div id="取引先データ-取引先データ更新-put" class="action put"><h4 class="action-heading"><div class="name"></div><a href="#取引先データ-取引先データ更新-put" class="method put">PUT</a><code class="uri">/api/v1/customers/{id}</code></h4><h4 id="header-処理概要-19">処理概要 <a class="permalink" href="#header-処理概要-19" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="取引先データ-取引先データ更新" class="resource"><h3 class="resource-heading">取引先データ更新 <a href="#取引先データ-取引先データ更新" class="permalink">&nbsp;&para;</a></h3><div id="取引先データ-取引先データ更新-put" class="action put"><h4 class="action-heading"><div class="name"></div><a href="#取引先データ-取引先データ更新-put" class="method put">PUT</a><code class="uri">/api/v1/customers/{id}</code></h4><h4 id="header-処理概要-28">処理概要 <a class="permalink" href="#header-処理概要-28" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>特定の取引先データを更新します</p>
@@ -2719,6 +3934,9 @@ https://web.zaico.co.jp/api/v1/customers?page=1</code></pre>
 <p>敬称は 様 または 御中が指定可能です</p>
 </li>
 <li>
+<p>入出庫区分は「packing_slip」または「purchase」が指定可能です</p>
+</li>
+<li>
 <p>該当する取引先データが無い場合はエラーを返します</p>
 </li>
 <li>
@@ -2726,7 +3944,73 @@ https://web.zaico.co.jp/api/v1/customers?page=1</code></pre>
 </li>
 </ul>
 <h4>Example URI</h4><div class="definition"><span class="method put">PUT</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/customers/<span class="hljs-attribute" title="id">1</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>id</dt><dd><code>number</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>1</span></span><p>取引先データのID</p>
-</dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+</dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
+  "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"取引先A"</span></span>,
+  "<span class="hljs-attribute">email</span>": <span class="hljs-value"><span class="hljs-string">"zaico@example.com"</span></span>,
+  "<span class="hljs-attribute">name_postfix</span>": <span class="hljs-value"><span class="hljs-string">"様"</span></span>,
+  "<span class="hljs-attribute">zip</span>": <span class="hljs-value"><span class="hljs-string">"1234567"</span></span>,
+  "<span class="hljs-attribute">address</span>": <span class="hljs-value"><span class="hljs-string">"東京都港区"</span></span>,
+  "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"港ビル"</span></span>,
+  "<span class="hljs-attribute">phone_number</span>": <span class="hljs-value"><span class="hljs-string">"08012345678"</span></span>,
+  "<span class="hljs-attribute">etc</span>": <span class="hljs-value"><span class="hljs-string">"取引先"</span></span>,
+  "<span class="hljs-attribute">fax_number</span>": <span class="hljs-value"><span class="hljs-string">"5678"</span></span>,
+  "<span class="hljs-attribute">category</span>": <span class="hljs-value"><span class="hljs-string">"東京"</span></span>,
+  "<span class="hljs-attribute">customer_type</span>": <span class="hljs-value"><span class="hljs-string">"packing_slip"</span></span>,
+  "<span class="hljs-attribute">num</span>": <span class="hljs-value"><span class="hljs-string">"1"</span>
+</span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+  "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+  "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">name</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"取引先名"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">email</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メールアドレス"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">name_postfix</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"敬称"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">zip</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"郵便番号"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">address</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"住所"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">building_name</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"建物名・部屋番号"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">phone_number</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"電話番号"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">etc</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"備考"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">fax_number</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"FAX番号"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">category</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"カテゴリ"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">customer_type</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"入出庫区分"</span>
+    </span>}</span>,
+    "<span class="hljs-attribute">num</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+      "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"取引先No."</span>
+    </span>}
+  </span>}
+</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">code</span>": <span class="hljs-value"><span class="hljs-number">200</span></span>,
   "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"success"</span></span>,
   "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Data was successfully updated"</span></span>,
@@ -2794,7 +4078,7 @@ https://web.zaico.co.jp/api/v1/customers?page=1</code></pre>
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="取引先データ-取引先データ削除" class="resource"><h3 class="resource-heading">取引先データ削除 <a href="#取引先データ-取引先データ削除" class="permalink">&nbsp;&para;</a></h3><div id="取引先データ-取引先データ削除-delete" class="action delete"><h4 class="action-heading"><div class="name"></div><a href="#取引先データ-取引先データ削除-delete" class="method delete">DELETE</a><code class="uri">/api/v1/customers/{id}</code></h4><h4 id="header-処理概要-20">処理概要 <a class="permalink" href="#header-処理概要-20" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="取引先データ-取引先データ削除" class="resource"><h3 class="resource-heading">取引先データ削除 <a href="#取引先データ-取引先データ削除" class="permalink">&nbsp;&para;</a></h3><div id="取引先データ-取引先データ削除-delete" class="action delete"><h4 class="action-heading"><div class="name"></div><a href="#取引先データ-取引先データ削除-delete" class="method delete">DELETE</a><code class="uri">/api/v1/customers/{id}</code></h4><h4 id="header-処理概要-29">処理概要 <a class="permalink" href="#header-処理概要-29" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>特定の取引先データを削除します</p>
@@ -2851,7 +4135,7 @@ https://web.zaico.co.jp/api/v1/customers?page=1</code></pre>
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"メッセージ"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="発送元データ" class="resource-group"><h2 class="group-heading">発送元データ <a href="#発送元データ" class="permalink">&para;</a></h2><div id="発送元データ-発送元データ一覧取得" class="resource"><h3 class="resource-heading">発送元データ一覧取得 <a href="#発送元データ-発送元データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="発送元データ-発送元データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#発送元データ-発送元データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/shipping_clients/</code></h4><h4 id="header-処理概要-21">処理概要 <a class="permalink" href="#header-処理概要-21" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="発送元データ" class="resource-group"><h2 class="group-heading">発送元データ <a href="#発送元データ" class="permalink">&para;</a></h2><div id="発送元データ-発送元データ一覧取得" class="resource"><h3 class="resource-heading">発送元データ一覧取得 <a href="#発送元データ-発送元データ一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="発送元データ-発送元データ一覧取得-get" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#発送元データ-発送元データ一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/shipping_clients/</code></h4><h4 id="header-処理概要-30">処理概要 <a class="permalink" href="#header-処理概要-30" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>フルプランのみ参照できます。</p>
@@ -2877,19 +4161,10 @@ https://web.zaico.co.jp/api/v1/customers?page=1</code></pre>
 https://web.zaico.co.jp/api/v1/shipping_clients?page=1</code></pre>
 </li>
 </ul>
-<h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/shipping_clients/</span></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span><br><span class="hljs-attribute">Link</span>: <span class="hljs-string">&lt;https://web.zaico.co.jp/api/v1/shipping_clients?page=1&gt;; rel="first", &lt;https://web.zaico.co.jp/api/v1/shipping_clients?page=1&gt;; rel="last"</span><br><span class="hljs-attribute">Total-Count</span>: <span class="hljs-string">発送元データ件数</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>[
-  {
-    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
-    "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"発送元A"</span></span>,
-    "<span class="hljs-attribute">zip</span>": <span class="hljs-value"><span class="hljs-string">"1234567"</span></span>,
-    "<span class="hljs-attribute">address</span>": <span class="hljs-value"><span class="hljs-string">"東京都港区"</span></span>,
-    "<span class="hljs-attribute">building_name</span>": <span class="hljs-value"><span class="hljs-string">"港ビル"</span></span>,
-    "<span class="hljs-attribute">phone_number</span>": <span class="hljs-value"><span class="hljs-string">"08012345678"</span>
-  </span>}
-]</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
+<h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/shipping_clients/</span></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span><br><span class="hljs-attribute">Link</span>: <span class="hljs-string">&lt;https://web.zaico.co.jp/api/v1/shipping_clients?page=1&gt;; rel="first", &lt;https://web.zaico.co.jp/api/v1/shipping_clients?page=1&gt;; rel="last"</span><br><span class="hljs-attribute">Total-Count</span>: <span class="hljs-string">発送元データ件数</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>[]</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
-  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span>
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="在庫グループビューデータ" class="resource-group"><h2 class="group-heading">在庫グループビューデータ <a href="#在庫グループビューデータ" class="permalink">&para;</a></h2><div id="在庫グループビューデータ-一覧取得" class="resource"><h3 class="resource-heading">一覧取得 <a href="#在庫グループビューデータ-一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="在庫グループビューデータ-一覧取得-get" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#在庫グループビューデータ-一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/inventory_group_items</code></h4><h4 id="header-処理概要-22">処理概要 <a class="permalink" href="#header-処理概要-22" aria-hidden="true">¶</a></h4>
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section><section id="在庫グループビューデータ" class="resource-group"><h2 class="group-heading">在庫グループビューデータ <a href="#在庫グループビューデータ" class="permalink">&para;</a></h2><div id="在庫グループビューデータ-一覧取得" class="resource"><h3 class="resource-heading">一覧取得 <a href="#在庫グループビューデータ-一覧取得" class="permalink">&nbsp;&para;</a></h3><div id="在庫グループビューデータ-一覧取得-get" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#在庫グループビューデータ-一覧取得-get" class="method get">GET</a><code class="uri">/api/v1/inventory_group_items</code></h4><h4 id="header-処理概要-31">処理概要 <a class="permalink" href="#header-処理概要-31" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>フルプランの方のみ利用可能です</p>
@@ -2929,9 +4204,9 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
 <h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname">https://web.zaico.co.jp</span>/api/v1/inventory_group_items</span></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span><br><span class="hljs-attribute">Link</span>: <span class="hljs-string">&lt;https://web.zaico.co.jp/api/v1/inventory_group_items?page=1&gt;; rel="first", &lt;https://web.zaico.co.jp/api/v1/inventory_group_items?page=前のページ&gt;; rel="prev", &lt;https://web.zaico.co.jp/api/v1/inventory_group_items?page=次のページ&gt;; rel="next", &lt;https://web.zaico.co.jp/api/v1/inventory_group_items?page=最後のページ&gt;; rel="last"</span><br><span class="hljs-attribute">Total-Count</span>: <span class="hljs-string">在庫グループビューデータ件数</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
   "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"在庫データ"</span></span>,
-  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
-  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
-  "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
+  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
   "<span class="hljs-attribute">order_point_warning</span>": <span class="hljs-value"><span class="hljs-literal">false</span></span>,
   "<span class="hljs-attribute">group_value</span>": <span class="hljs-value"><span class="hljs-string">"グループタグ"</span></span>,
   "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span></span>,
@@ -2949,15 +4224,15 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"タイトル"</span>
     </span>}</span>,
     "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"数量"</span>
     </span>}</span>,
     "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"予定フリー在庫数"</span>
     </span>}</span>,
     "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発注点（発注点機能がONの場合のみ）"</span>
     </span>}</span>,
     "<span class="hljs-attribute">order_point_warning</span>": <span class="hljs-value">{
@@ -2977,7 +4252,7 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"更新日"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="在庫グループビューデータ-個別取得" class="resource"><h3 class="resource-heading">個別取得 <a href="#在庫グループビューデータ-個別取得" class="permalink">&nbsp;&para;</a></h3><div id="在庫グループビューデータ-個別取得-get" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#在庫グループビューデータ-個別取得-get" class="method get">GET</a><code class="uri">/api/v1/inventory_group_items/{id}</code></h4><h4 id="header-処理概要-23">処理概要 <a class="permalink" href="#header-処理概要-23" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="在庫グループビューデータ-個別取得" class="resource"><h3 class="resource-heading">個別取得 <a href="#在庫グループビューデータ-個別取得" class="permalink">&nbsp;&para;</a></h3><div id="在庫グループビューデータ-個別取得-get" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#在庫グループビューデータ-個別取得-get" class="method get">GET</a><code class="uri">/api/v1/inventory_group_items/{id}</code></h4><h4 id="header-処理概要-32">処理概要 <a class="permalink" href="#header-処理概要-32" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>在庫グループビューデータを1件のみ取得します</p>
@@ -2994,9 +4269,9 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
 </dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
   "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"在庫データ"</span></span>,
-  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
-  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
-  "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
+  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
   "<span class="hljs-attribute">order_point_warning</span>": <span class="hljs-value"><span class="hljs-literal">false</span></span>,
   "<span class="hljs-attribute">group_value</span>": <span class="hljs-value"><span class="hljs-string">"グループタグ"</span></span>,
   "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span></span>,
@@ -3014,15 +4289,15 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"タイトル"</span>
     </span>}</span>,
     "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"数量"</span>
     </span>}</span>,
     "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"予定フリー在庫数"</span>
     </span>}</span>,
     "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発注点（発注点機能がONの場合のみ）"</span>
     </span>}</span>,
     "<span class="hljs-attribute">order_point_warning</span>": <span class="hljs-value">{
@@ -3063,7 +4338,7 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"エラー内容"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="在庫グループビューデータ-発注点の設定" class="resource"><h3 class="resource-heading">発注点の設定 <a href="#在庫グループビューデータ-発注点の設定" class="permalink">&nbsp;&para;</a></h3><div id="在庫グループビューデータ-発注点の設定-put" class="action put"><h4 class="action-heading"><div class="name"></div><a href="#在庫グループビューデータ-発注点の設定-put" class="method put">PUT</a><code class="uri">/api/v1/inventory_group_items/{id}/order_points</code></h4><h4 id="header-処理概要-24">処理概要 <a class="permalink" href="#header-処理概要-24" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="在庫グループビューデータ-発注点の設定" class="resource"><h3 class="resource-heading">発注点の設定 <a href="#在庫グループビューデータ-発注点の設定" class="permalink">&nbsp;&para;</a></h3><div id="在庫グループビューデータ-発注点の設定-put" class="action put"><h4 class="action-heading"><div class="name"></div><a href="#在庫グループビューデータ-発注点の設定-put" class="method put">PUT</a><code class="uri">/api/v1/inventory_group_items/{id}/order_points</code></h4><h4 id="header-処理概要-33">処理概要 <a class="permalink" href="#header-処理概要-33" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>在庫グループビューデータに対して発注点を設定します</p>
@@ -3091,9 +4366,9 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
 </span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
   "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"在庫データ"</span></span>,
-  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
-  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
-  "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
+  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
   "<span class="hljs-attribute">order_point_warning</span>": <span class="hljs-value"><span class="hljs-literal">false</span></span>,
   "<span class="hljs-attribute">group_value</span>": <span class="hljs-value"><span class="hljs-string">"グループタグ"</span></span>,
   "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span></span>,
@@ -3111,15 +4386,15 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"タイトル"</span>
     </span>}</span>,
     "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"数量"</span>
     </span>}</span>,
     "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"予定フリー在庫数"</span>
     </span>}</span>,
     "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発注点（発注点機能がONの場合のみ）"</span>
     </span>}</span>,
     "<span class="hljs-attribute">order_point_warning</span>": <span class="hljs-value">{
@@ -3160,7 +4435,7 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"エラー内容"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="在庫グループビューデータ-発注点の警告on" class="resource"><h3 class="resource-heading">発注点の警告ON <a href="#在庫グループビューデータ-発注点の警告on" class="permalink">&nbsp;&para;</a></h3><div id="在庫グループビューデータ-発注点の警告on-post" class="action post"><h4 class="action-heading"><div class="name"></div><a href="#在庫グループビューデータ-発注点の警告on-post" class="method post">POST</a><code class="uri">/api/v1/inventory_group_items/{id}/order_points/warning_on</code></h4><h4 id="header-処理概要-25">処理概要 <a class="permalink" href="#header-処理概要-25" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="在庫グループビューデータ-発注点の警告on" class="resource"><h3 class="resource-heading">発注点の警告ON <a href="#在庫グループビューデータ-発注点の警告on" class="permalink">&nbsp;&para;</a></h3><div id="在庫グループビューデータ-発注点の警告on-post" class="action post"><h4 class="action-heading"><div class="name"></div><a href="#在庫グループビューデータ-発注点の警告on-post" class="method post">POST</a><code class="uri">/api/v1/inventory_group_items/{id}/order_points/warning_on</code></h4><h4 id="header-処理概要-34">処理概要 <a class="permalink" href="#header-処理概要-34" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>在庫グループビューデータの数量が発注点以下の場合の警告表示状態をONにします。</p>
@@ -3177,9 +4452,9 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
 </dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
   "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"在庫データ"</span></span>,
-  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
-  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
-  "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
+  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
   "<span class="hljs-attribute">order_point_warning</span>": <span class="hljs-value"><span class="hljs-literal">false</span></span>,
   "<span class="hljs-attribute">group_value</span>": <span class="hljs-value"><span class="hljs-string">"グループタグ"</span></span>,
   "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span></span>,
@@ -3197,15 +4472,15 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"タイトル"</span>
     </span>}</span>,
     "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"数量"</span>
     </span>}</span>,
     "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"予定フリー在庫数"</span>
     </span>}</span>,
     "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発注点（発注点機能がONの場合のみ）"</span>
     </span>}</span>,
     "<span class="hljs-attribute">order_point_warning</span>": <span class="hljs-value">{
@@ -3246,7 +4521,7 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"エラー内容"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="在庫グループビューデータ-発注点の警告off" class="resource"><h3 class="resource-heading">発注点の警告OFF <a href="#在庫グループビューデータ-発注点の警告off" class="permalink">&nbsp;&para;</a></h3><div id="在庫グループビューデータ-発注点の警告off-post" class="action post"><h4 class="action-heading"><div class="name"></div><a href="#在庫グループビューデータ-発注点の警告off-post" class="method post">POST</a><code class="uri">/api/v1/inventory_group_items/{id}/order_points/warning_off</code></h4><h4 id="header-処理概要-26">処理概要 <a class="permalink" href="#header-処理概要-26" aria-hidden="true">¶</a></h4>
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="在庫グループビューデータ-発注点の警告off" class="resource"><h3 class="resource-heading">発注点の警告OFF <a href="#在庫グループビューデータ-発注点の警告off" class="permalink">&nbsp;&para;</a></h3><div id="在庫グループビューデータ-発注点の警告off-post" class="action post"><h4 class="action-heading"><div class="name"></div><a href="#在庫グループビューデータ-発注点の警告off-post" class="method post">POST</a><code class="uri">/api/v1/inventory_group_items/{id}/order_points/warning_off</code></h4><h4 id="header-処理概要-35">処理概要 <a class="permalink" href="#header-処理概要-35" aria-hidden="true">¶</a></h4>
 <ul>
 <li>
 <p>在庫グループビューデータの数量が発注点以下の場合の警告表示状態をOFFにします。</p>
@@ -3263,9 +4538,9 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
 </dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Authorization</span>: <span class="hljs-string">Bearer YOUR_TOKEN</span><br><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
   "<span class="hljs-attribute">title</span>": <span class="hljs-value"><span class="hljs-string">"在庫データ"</span></span>,
-  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
-  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
-  "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-number">10</span></span>,
+  "<span class="hljs-attribute">quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
+  "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-string">"10"</span></span>,
   "<span class="hljs-attribute">order_point_warning</span>": <span class="hljs-value"><span class="hljs-literal">false</span></span>,
   "<span class="hljs-attribute">group_value</span>": <span class="hljs-value"><span class="hljs-string">"グループタグ"</span></span>,
   "<span class="hljs-attribute">created_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span></span>,
@@ -3283,15 +4558,15 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"タイトル"</span>
     </span>}</span>,
     "<span class="hljs-attribute">quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"数量"</span>
     </span>}</span>,
     "<span class="hljs-attribute">logical_quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"予定フリー在庫数"</span>
     </span>}</span>,
     "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"number"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"発注点（発注点機能がONの場合のみ）"</span>
     </span>}</span>,
     "<span class="hljs-attribute">order_point_warning</span>": <span class="hljs-value">{
@@ -3332,7 +4607,7 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"エラー内容"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 15 Mar 2024</p><script>/* eslint-env browser */
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 11 Apr 2025</p><script>/* eslint-env browser */
 /* eslint quotes: [2, "single"] */
 'use strict';
 

--- a/includes/api/inventories.md
+++ b/includes/api/inventories.md
@@ -177,7 +177,7 @@
 
 ### InventoryCreateParams
 + title: `在庫データ` (string, required) - 在庫データタイトル
-+ quantity: 10 (number) - 数量
++ quantity: 10 (string) - 数量
 + unit: `個` (string) - 単位
 + category: `製品` (string) - カテゴリ
 + state: `新品` (string) - 状態
@@ -194,7 +194,7 @@
     + name: `追加項目名` (string) - 追加項目名
     + value: `追加項目値` (string) - 追加項目値
 + quantity_management_attributes
-  + order_point_quantity: 5 (number) - 発注点
+  + order_point_quantity: 5 (string) - 発注点
 + inventory_history
   + memo: `変更履歴メモ` (string) - 変更履歴のメモ
 + is_quantity_auto_conversion_by_unit: `1` (string) - 単位換算するかどうか。"1"なら単位換算する、"0"なら単位換算しない
@@ -204,8 +204,8 @@
 ### InventoriesViews
 + id: 1 (number) - ID
 + title: `在庫データ` (string) - 在庫データタイトル
-+ quantity: 10 (number) - 数量
-+ logical_quantity: 10 (number) - 予定フリー在庫数（フルプランのみ）
++ quantity: 10 (string) - 数量
++ logical_quantity: 10 (string) - 予定フリー在庫数（フルプランのみ）
 + unit: `個` (string) - 単位
 + category: `製品` (string) - カテゴリ
 + state: `新品` (string) - 状態
@@ -222,7 +222,7 @@
     + name: `追加項目名` (string) - 追加項目名
     + value: `追加項目値` (string) - 追加項目値
 + quantity_management_attributes
-  + order_point_quantity: 5 (number) - 発注点
+  + order_point_quantity: 5 (string) - 発注点
 + created_at: `2018-03-27T09:38:19+09:00` (string) - 作成日
 + updated_at `2018-03-27T09:38:19+09:00` (string) - 更新日
 + create_user_name: `田村 太郎` (string) - 作成者

--- a/includes/api/inventories_sets.md
+++ b/includes/api/inventories_sets.md
@@ -41,29 +41,29 @@
        + (object)
            + id: 123 (number) - ID
            + title: `セット品A` (string) - セット品名 
-           + price: 1000 (number) - 価格
+           + price: 1000 (string) - 価格
            + code: `123456` (string) - コード
            + memo: `メモ` (string) - メモ  
            + update_user_id: 1 (number) - 更新ユーザーID
-           + available_delivery_quantity: 5 (number) - 出庫可能数量
+           + available_delivery_quantity: 5 (string) - 出庫可能数量
            + created_at: `2022-01-01 09:00:00` (string) - 作成日時
            + updated_at: `2022-01-02 10:00:00` (string) - 更新日時
            + inventories_set_items (array[object], fixed-type)
                + (object)
                    + inventory_id: 1 (number) - 在庫ID
-                   + quantity: 1 (number) - 数量
+                   + quantity: 1 (string) - 数量
                    + created_at: `2022-01-01 09:00:00` (string) - 作成日時
                    + updated_at: `2022-01-02 10:00:00` (string) - 更新日時
                    + inventory_title: `構成部品A` (string) - 在庫名
-                   + inventory_quantity: 10 (number) - 在庫数量
+                   + inventory_quantity: 10 (string) - 在庫数量
                    + inventory_del_flg: false (boolean) - 在庫削除フラグ   
                + (object)
                    + inventory_id: 2 (number)
-                   + quantity: 2 (number)
+                   + quantity: 2 (string)
                    + created_at: `2022-01-01 09:00:00` (string)
                    + updated_at: `2022-01-02 10:00:00` (string)
                    + inventory_title: `構成部品B` (string)
-                   + inventory_quantity: 20 (number)
+                   + inventory_quantity: 20 (string)
                    + inventory_del_flg: false (boolean)
       
 ## セット品データ作成 [/api/v1/inventories_sets] 
@@ -139,32 +139,32 @@
    + Attributes
        + id: 123 (number) - セット品ID
        + title: `セット品A` (string) - セット品名
-       + price: 1000 (number) - 価格
+       + price: 1000 (string) - 価格
        + code: `123456` (string) - コード
        + memo: `メモ` (string) - メモ
        + update_user_id: 1 (number) - 更新ユーザーID
-       + available_delivery_quantity: 5 (number) - 出庫可能数量 
-       + available_delivery_logical_quantity: 3 (number) - 予定フリー出庫可能数量
+       + available_delivery_quantity: 5 (string) - 出庫可能数量 
+       + available_delivery_logical_quantity: 3 (string) - 予定フリー出庫可能数量
        + created_at: `2022-01-01 09:00:00` (string) - 作成日時
        + updated_at: `2022-01-02 10:00:00` (string) - 更新日時
        + inventories_set_items (array[object], fixed-type)
            + (object) 
                + inventory_id: 1 (number) - 在庫ID
-               + quantity: 1 (number) - 数量
+               + quantity: 1 (string) - 数量
                + created_at: `2022-01-01 09:00:00` (string) - 作成日時
                + updated_at: `2022-01-02 10:00:00` (string) - 更新日時
                + inventory_title: `構成部品A` (string) - 在庫名
-               + inventory_quantity: 10 (number) - 在庫数量 
-               + inventory_logical_quantity: 8 (number) - 予定フリー在庫数
+               + inventory_quantity: 10 (string) - 在庫数量 
+               + inventory_logical_quantity: 8 (string) - 予定フリー在庫数
                + inventory_del_flg: false (boolean) - 在庫削除フラグ
            + (object)
                + inventory_id: 2 (number)
-               + quantity: 2 (number)
+               + quantity: 2 (string)
                + created_at: `2022-01-01 09:00:00` (string)
                + updated_at: `2022-01-02 10:00:00` (string)
                + inventory_title: `構成部品B` (string)
-               + inventory_quantity: 20 (number)
-               + inventory_logical_quantity: 18 (number)
+               + inventory_quantity: 20 (string)
+               + inventory_logical_quantity: 18 (string)
                + inventory_del_flg: false (boolean)
      
 + Response 404 (application/json)

--- a/includes/api/inventory_group_items.md
+++ b/includes/api/inventory_group_items.md
@@ -132,9 +132,9 @@
 ### InventoryGroupItemsViews
 + id: 1 (number) - ID
 + title: `在庫データ` (string) - タイトル
-+ quantity: 10 (number) - 数量
-+ logical_quantity: 10 (number) - 予定フリー在庫数
-+ order_point_quantity: 10 (number) - 発注点（発注点機能がONの場合のみ）
++ quantity: 10 (string) - 数量
++ logical_quantity: 10 (string) - 予定フリー在庫数
++ order_point_quantity: 10 (string) - 発注点（発注点機能がONの場合のみ）
 + order_point_warning: false (boolean) - 発注点の警告ON/OFF（発注点機能がONの場合のみ）
 + group_value: `グループタグ` (string) - グループタグ
 + created_at: `2018-03-27T09:38:19+09:00` (string) - 作成日

--- a/includes/api/packing_slips.md
+++ b/includes/api/packing_slips.md
@@ -90,9 +90,9 @@
                     + id: 1 (number)
                     + inventory_id: 1 (number)
                     + title: 掃除機 (string) - 物品名
-                    + quantity: 3 (number) - 出庫数量
+                    + quantity: 3 (string) - 出庫数量
                     + unit: 台 (string) - 単位
-                    + unit_price: 100 (number) - 納品単価
+                    + unit_price: 100 (string) - 納品単価
                     + status: completed_delivery (string)
                     + delivery_date: `2019-09-01` (string)
                     + estimated_delivery_date (string, optional, nullable)
@@ -101,9 +101,9 @@
                     + id: 2 (number)
                     + inventory_id: 2 (number)
                     + title: テレビ (string) - 物品名
-                    + quantity: 3 (number) - 出庫数量
+                    + quantity: 3 (string) - 出庫数量
                     + unit: 台 (string) - 単位
-                    + unit_price: 100 (number) - 納品単価
+                    + unit_price: 100 (string) - 納品単価
                     + status: completed_delivery (string)
                     + delivery_date: `2019-09-01` (string)
                     + estimated_delivery_date (string, optional, nullable)
@@ -112,11 +112,11 @@
                     + id: 3 (number)
                     + inventory_id: 3 (number)
                     + title: ビール (string) - 物品名
-                    + quantity: 12 (number) - 出庫数量
+                    + quantity: 12 (string) - 出庫数量
                     + box_quantity: 1 (string) - まとめ換算の入庫数量
                     + unit: 瓶 (string) - 単位
                     + box_unit: 箱 (string) - まとめ単位
-                    + unit_price: 100 (number) - 納品単価
+                    + unit_price: 100 (string) - 納品単価
                     + unit_snapshot:
                         + piece_name: 瓶 (string) - 基本単位名称
                         + box_name: 箱 (string) - まとめ単位名称
@@ -140,9 +140,9 @@
                 + (object)
                     + inventory_id: 5 (number)
                     + title: 掃除機 (string) - 物品名
-                    + quantity: 3 (number) - 出庫数量
+                    + quantity: 3 (string) - 出庫数量
                     + unit: 台 (string) - 単位
-                    + unit_price: 100 (number) - 納品単価
+                    + unit_price: 100 (string) - 納品単価
                     + status: completed_delivery
                     + delivery_date: `2019-09-01`
                     + estimated_delivery_date: `2019-09-01` (string, optional, nullable)
@@ -311,9 +311,9 @@
             + (object)
                 + inventory_id: 1 (number)
                 + title: 掃除機 (string) - 物品名
-                + quantity: 3 (number) - 出庫数量
+                + quantity: 3 (string) - 出庫数量
                 + unit: 台 (string) - 単位
-                + unit_price: 100 (number) - 納品単価
+                + unit_price: 100 (string) - 納品単価
                 + status: completed_delivery (string)
                 + delivery_date: `2019-09-01` (string)
                 + estimated_delivery_date (string, optional, nullable)
@@ -321,9 +321,9 @@
             + (object)
                 + inventory_id: 2 (number)
                 + title: テレビ (string) - 物品名
-                + quantity: 3 (number) - 出庫数量
+                + quantity: 3 (string) - 出庫数量
                 + unit: 台 (string) - 単位
-                + unit_price: 100 (number) - 納品単価
+                + unit_price: 100 (string) - 納品単価
                 + status: completed_delivery (string)
                 + delivery_date: `2019-09-01` (string)
                 + estimated_delivery_date: `2019-09-01` (string, optional, nullable)
@@ -474,9 +474,9 @@
             + packing_slip_id: 10 (number)
             + inventory_id: 1 (number)
             + title: 掃除機 (string)
-            + quantity: 3 (number)
+            + quantity: 3 (string)
             + unit: 台 (string)
-            + unit_price: 100 (number)
+            + unit_price: 100 (string)
             + status: completed_delivery (string)
             + delivery_date: 2021-11-17 (string)
             + estimated_delivery_date: (string, nullable)
@@ -488,9 +488,9 @@
             + packing_slip_id: 10 (number)
             + inventory_id: 1 (number)
             + title: 掃除機 (string)
-            + quantity: 3 (number)
+            + quantity: 3 (string)
             + unit: 台 (string)
-            + unit_price: 100 (number)
+            + unit_price: 100 (string)
             + status: completed_delivery (string)
             + delivery_date: 2021-11-17 (string)
             + estimated_delivery_date: (string, nullable)

--- a/includes/api/purchases.md
+++ b/includes/api/purchases.md
@@ -49,7 +49,7 @@ HOST: https://web.zaico.co.jp/
             * 以下の3つのいずれかが設定されています
             * not_ordered : 発注前
             * ordered : 発注済み
-            * purchased : 入庫済み
+            * purchased : 入庫済
         * purchase_date: 入庫日
         * estimated_purchase_date : 入庫予定日
         * etc : 入庫物品メモ
@@ -506,9 +506,9 @@ HOST: https://web.zaico.co.jp/
             + purchase_id: 10 (number)
             + inventory_id: 1 (number)
             + title: 掃除機 (string)
-            + quantity: 3 (number)
+            + quantity: 3 (string)
             + unit: 台 (string)
-            + unit_price: 100 (number)
+            + unit_price: 100 (string)
             + status: purchased (string)
             + purchase_date: 2021-11-17 (string)
             + estimated_purchase_date: (string, nullable)
@@ -519,9 +519,9 @@ HOST: https://web.zaico.co.jp/
             + purchase_id: 10 (number)
             + inventory_id: 2 (number)
             + title: りんご (string)
-            + quantity: 10 (number)
+            + quantity: 10 (string)
             + unit: 個 (string)
-            + unit_price: 200 (number)
+            + unit_price: 200 (string)
             + status: purchased (string)
             + purchase_date: 2021-11-17 (string)
             + estimated_purchase_date: (string, nullable)


### PR DESCRIPTION
<!-- Github Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

## 背景・課題
https://zaicozaico.atlassian.net/browse/DEV-8096

## 対応概要
- 一部のAPIのレスポンスで、実際はstring型で返している項目がnumberと記載されている
  - HubSpotを確認したところ、全体的にそうなっているようなので一括で置換
  - Response側のみ修正、Request側のパラメータとして記載されている部分はそのまま