### PR TITLE
DEV-8145 在庫作成・更新APIの追加項目部分のリクエストパラメータの記載が間違っているのを修正

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:

--- a/dist/index.html
+++ b/dist/index.html
@@ -281,8 +281,10 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">checked_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span>
   </span>}</span>,
   "<span class="hljs-attribute">optional_attributes</span>": <span class="hljs-value">[
-    <span class="hljs-string">"name: `追加項目名`"</span>,
-    <span class="hljs-string">"value: `追加項目値`"</span>
+    {
+      "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"追加項目名"</span></span>,
+      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"追加項目値"</span>
+    </span>}
   ]</span>,
   "<span class="hljs-attribute">quantity_management_attributes</span>": <span class="hljs-value">{
     "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-string">"5"</span>
@@ -351,14 +353,19 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     </span>}</span>,
     "<span class="hljs-attribute">optional_attributes</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span></span>,
-      "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
-        {
-          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
-        </span>},
-        {
-          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+      "<span class="hljs-attribute">items</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+        "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">name</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+            "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"追加項目名"</span>
+          </span>}</span>,
+          "<span class="hljs-attribute">value</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+            "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"追加項目値"</span>
+          </span>}
         </span>}
-      ]
+      </span>}
     </span>}</span>,
     "<span class="hljs-attribute">quantity_management_attributes</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
@@ -734,8 +741,10 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     "<span class="hljs-attribute">checked_at</span>": <span class="hljs-value"><span class="hljs-string">"2018-03-27T09:38:19+09:00"</span>
   </span>}</span>,
   "<span class="hljs-attribute">optional_attributes</span>": <span class="hljs-value">[
-    <span class="hljs-string">"name: `追加項目名`"</span>,
-    <span class="hljs-string">"value: `追加項目値`"</span>
+    {
+      "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"追加項目名"</span></span>,
+      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"追加項目値"</span>
+    </span>}
   ]</span>,
   "<span class="hljs-attribute">quantity_management_attributes</span>": <span class="hljs-value">{
     "<span class="hljs-attribute">order_point_quantity</span>": <span class="hljs-value"><span class="hljs-string">"5"</span>
@@ -804,14 +813,19 @@ https://web.zaico.co.jp/api/v1/inventories/?title=在庫データ&amp;category=�
     </span>}</span>,
     "<span class="hljs-attribute">optional_attributes</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"array"</span></span>,
-      "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
-        {
-          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
-        </span>},
-        {
-          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
+      "<span class="hljs-attribute">items</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+        "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">name</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+            "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"追加項目名"</span>
+          </span>}</span>,
+          "<span class="hljs-attribute">value</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+            "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"追加項目値"</span>
+          </span>}
         </span>}
-      ]
+      </span>}
     </span>}</span>,
     "<span class="hljs-attribute">quantity_management_attributes</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
@@ -4607,7 +4621,7 @@ https://web.zaico.co.jp/api/v1/inventory_group_items/?group_value=SKU-1&amp;titl
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"エラー内容"</span>
     </span>}
   </span>}
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 11 Apr 2025</p><script>/* eslint-env browser */
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 25 Apr 2025</p><script>/* eslint-env browser */
 /* eslint quotes: [2, "single"] */
 'use strict';
 

--- a/includes/api/inventories.md
+++ b/includes/api/inventories.md
@@ -53,8 +53,8 @@
 
 + Request
   + Headers
-  Authorization: Bearer YOUR_TOKEN
-  Content-Type: application/json
+      Authorization: Bearer YOUR_TOKEN
+      Content-Type: application/json
   + Params
   + Attributes (InventoryCreateParams)
 
@@ -116,8 +116,8 @@
 
 + Request
   + Headers
-  Authorization: Bearer YOUR_TOKEN
-  Content-Type: application/json
+      Authorization: Bearer YOUR_TOKEN
+      Content-Type: application/json
   + Params
   + Attributes (InventoryCreateParams)
 
@@ -189,10 +189,10 @@
 + item_image: `base64-encoded-image` (string)
 + stocktake_attributes
   + checked_at: `2018-03-27T09:38:19+09:00` (string) - 棚卸日
-+ optional_attributes (array[object],fixed-type)
-  + (object)
-    + name: `追加項目名` (string) - 追加項目名
-    + value: `追加項目値` (string) - 追加項目値
++ optional_attributes (array[object], fixed-type)
+    + (object)
+        + name: `追加項目名` (string) - 追加項目名
+        + value: `追加項目値` (string) - 追加項目値
 + quantity_management_attributes
   + order_point_quantity: 5 (string) - 発注点
 + inventory_history


### PR DESCRIPTION
## 背景・課題
https://zaicozaico.atlassian.net/browse/DEV-8145

## 対応概要
- 在庫作成・更新APIで追加項目部分のリクエストパラメータの記載が間違っているのを修正
  - インデントは2じゃなくて4じゃないと正常に反映されない模様でした
- ついでに4/15にGithub Actionsで動かしているrunnerのubuntu-20.04が廃止されたのでubuntu-24.04に変更

## UI変更
### 今
![スクリーンショット 2025-04-25 11 02 34](https://github.com/user-attachments/assets/f4102500-4812-4fc0-85b8-4986c8a144f9)
![スクリーンショット 2025-04-25 11 03 33](https://github.com/user-attachments/assets/d2333d18-06ec-474c-82c0-3ce43f350f94)

### 修正後
![スクリーンショット 2025-04-25 11 03 47](https://github.com/user-attachments/assets/c1300172-1dac-46e8-a16e-562f3904a1c1)
![スクリーンショット 2025-04-25 11 03 53](https://github.com/user-attachments/assets/bd2d5366-a5c4-4291-8d51-42dada0560cd)
