### PR TITLE
docs: DEV-8924 公開API v2ドキュメントへのリンクを追加

### DIFF
--- a/api.md
+++ b/api.md
@@ -15,6 +15,8 @@ HOST: https://web.zaico.co.jp
 # zaico API Document
 このドキュメントはZAICO APIの機能と使うために必要なパラメータなどを説明するものです。
 
+新しい公開API v2のドキュメントは[こちら](https://internal-tools.zaico.co.jp/public-api-v2-doc/openapi.html)をご覧ください。
+
 2025年12月18日更新
 
 <!-- include(includes/authorization.md) -->


### PR DESCRIPTION
## Summary
- ZAICO API Documentの冒頭説明セクションに、公開API v2ドキュメント (https://internal-tools.zaico.co.jp/public-api-v2-doc/openapi.html) への導線リンクを追加しました。
- JIRA: [DEV-8924](https://zaicozaico.atlassian.net/browse/DEV-8924)

## 変更内容
`api.md` の冒頭に下記の案内文を1行追加。

> 新しい公開API v2のドキュメントは[こちら](https://internal-tools.zaico.co.jp/public-api-v2-doc/openapi.html)をご覧ください。

## 補足
- ローカル環境 (Linux + glibc新) では `protagonist` のネイティブビルドに失敗したため、`dist/index.html` の更新は本PRには含めていません。GitHub Actions側で `yarn build` が成功することを確認してください。masterへのマージ時にGitHub Pagesへも反映されます。

## Test plan
- [ ] GitHub Actions の `Build Document` ステップが成功すること
- [ ] PRアーティファクト (API Document) をダウンロードし、冒頭にリンクが表示されること
- [ ] リンク先 (https://internal-tools.zaico.co.jp/public-api-v2-doc/openapi.html) に遷移できること
- [ ] master マージ後、https://zaicodev.github.io/zaico_api_doc/ にも反映されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEV-8924]: https://zaicozaico.atlassian.net/browse/DEV-8924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ