### PR TITLE
docs: PLG-793 公開API v2ドキュメントのリンクを外部公開用URLに修正

### DIFF
--- a/api.md
+++ b/api.md
@@ -15,7 +15,7 @@ HOST: https://web.zaico.co.jp
 # zaico API Document
 このドキュメントはZAICO APIの機能と使うために必要なパラメータなどを説明するものです。
 
-新しい公開API v2のドキュメントは[こちら](https://internal-tools.zaico.co.jp/public-api-v2-doc/openapi.html)をご覧ください。
+新しい公開API v2のドキュメントは[こちら](https://public-docs.zaico.co.jp/public-api-v2-doc/openapi.html)をご覧ください。
 
 2025年12月18日更新
 


### PR DESCRIPTION
## Summary
- 公開API v2ドキュメントへのリンクが社内用URL (`internal-tools.zaico.co.jp`) になっていたため、外部公開用URL (`public-docs.zaico.co.jp`) に修正

## 背景
本リポジトリは GitHub Pages で外部公開されている API ドキュメントだが、`api.md` 冒頭の v2 ドキュメントへの導線リンクが社内用ホスト (`internal-tools.zaico.co.jp`) を指してしまっていた（DEV-8924 で追加された際に紛れ込んだもの）。外部利用者がリンクを開いてもアクセスできない状態だったため修正する。

## Test plan
- [x] `yarn dev` でローカル起動し、トップに表示されるリンクが `https://public-docs.zaico.co.jp/public-api-v2-doc/openapi.html` を指していることを確認
- [ ] master マージ後、GitHub Pages 上 (https://zaicodev.github.io/zaico_api_doc/) でリンク先が外部公開用URLになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)